### PR TITLE
리스크 검증 순서 교정 및 고정 슬롯 비중 배분

### DIFF
--- a/src/execution/executor.py
+++ b/src/execution/executor.py
@@ -293,26 +293,7 @@ class RebalanceExecutor:
                     "skipped": [],
                 }
 
-        # 1. 리스크 검증
-        risk_passed, risk_warnings = self.risk_guard.check_rebalance(target_weights)
-        if not risk_passed:
-            msg = f"리스크 검증 실패: {risk_warnings}"
-            logger.error(msg)
-            return {
-                "success": False,
-                "errors": [msg],
-                "sells": [],
-                "buys": [],
-                "total_sell_amount": 0,
-                "total_buy_amount": 0,
-                "skipped": [],
-            }
-
-        if risk_warnings:
-            for w in risk_warnings:
-                logger.warning("리스크 경고: %s", w)
-
-        # 2. 리밸런싱 주문 계산 (allocator가 있으면 풀 비중으로 스케일링)
+        # 1. allocator 스케일링 (있으면 풀 비중으로 조정)
         effective_weights = target_weights
         if self.allocator is not None:
             if pool == "etf_rotation":
@@ -330,11 +311,33 @@ class RebalanceExecutor:
                 sum(effective_weights.values()),
             )
 
+        # 2. 리스크 검증 (allocator 스케일링 후 최종 비중 기준)
+        risk_passed, risk_warnings = self.risk_guard.check_rebalance(
+            effective_weights
+        )
+        if not risk_passed:
+            msg = f"리스크 검증 실패: {risk_warnings}"
+            logger.error(msg)
+            return {
+                "success": False,
+                "errors": [msg],
+                "sells": [],
+                "buys": [],
+                "total_sell_amount": 0,
+                "total_buy_amount": 0,
+                "skipped": [],
+            }
+
+        if risk_warnings:
+            for w in risk_warnings:
+                logger.warning("리스크 경고: %s", w)
+
+        # 3. 리밸런싱 주문 계산
         sell_orders, buy_orders = self.position_manager.calculate_rebalance_orders(
             effective_weights, allocator=self.allocator, pool=pool
         )
 
-        # 3. 주문 배치 실행
+        # 4. 주문 배치 실행
         return self._execute_order_batch(sell_orders, buy_orders)
 
     def dry_run(
@@ -383,14 +386,7 @@ class RebalanceExecutor:
             logger.warning("DRY RUN: 포트폴리오 가치가 0원입니다.")
             return result
 
-        # 리스크 검증
-        risk_passed, risk_warnings = self.risk_guard.check_rebalance(target_weights)
-        result["risk_check"] = {
-            "passed": risk_passed,
-            "warnings": risk_warnings,
-        }
-
-        # 리밸런싱 주문 계산 (allocator가 있으면 풀 비중으로 스케일링)
+        # allocator 스케일링 (있으면 풀 비중으로 조정)
         effective_weights = target_weights
         if self.allocator is not None:
             if pool == "etf_rotation":
@@ -407,6 +403,15 @@ class RebalanceExecutor:
                 sum(target_weights.values()),
                 sum(effective_weights.values()),
             )
+
+        # 리스크 검증 (allocator 스케일링 후 최종 비중 기준)
+        risk_passed, risk_warnings = self.risk_guard.check_rebalance(
+            effective_weights
+        )
+        result["risk_check"] = {
+            "passed": risk_passed,
+            "warnings": risk_warnings,
+        }
 
         sell_orders, buy_orders = self.position_manager.calculate_rebalance_orders(
             effective_weights, allocator=self.allocator, pool=pool

--- a/src/scheduler/main.py
+++ b/src/scheduler/main.py
@@ -796,8 +796,8 @@ class TradingBot:
                 f"매수 가능 종목 {len(selected)}개 (최소 {min_stocks}개 미달)"
             )
 
-        # 동일 비중 재할당
-        weight = 1.0 / len(selected)
+        # 고정 슬롯 기준 비중 배분 — 선정 종목 < target이면 나머지는 현금 유지
+        weight = 1.0 / target_num_stocks
         filtered = {ticker: weight for ticker in selected}
 
         if excluded_reasons:

--- a/src/strategy/multi_factor.py
+++ b/src/strategy/multi_factor.py
@@ -546,8 +546,8 @@ class MultiFactorStrategy(Strategy):
             logger.warning(f"집중도 필터 후 후보 종목 없음 ({date})")
             return {}
 
-        # 동일 비중 할당
-        weight = 1.0 / len(top)
+        # 고정 슬롯 기준 비중 할당 — 선정 종목 < num_stocks이면 나머지는 현금 유지
+        weight = 1.0 / max(len(top), self.num_stocks)
         signals = {ticker: weight for ticker in top.index}
 
         # 마켓 타이밍 오버레이 적용

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1752,7 +1752,7 @@ class TestFilterAffordableSignals:
         assert bot._last_long_signals == {"005930": 0.5, "000660": 0.5}
 
     def test_reweights_equally(self):
-        """필터 후 동일 비중이 재할당된다."""
+        """필터 후 고정 슬롯 기준 비중이 재할당된다."""
         bot = self._make_bot()
         signals = {
             "A001": 0.2, "A002": 0.2, "A003": 0.2,
@@ -1767,10 +1767,11 @@ class TestFilterAffordableSignals:
             signals, {"prices": prices}, 70000, 7,
         )
 
-        # 4개 남으면 각 25%
+        # 4개 남으면 각 1/7 (고정 슬롯) — 미달 슬롯은 현금 유지
         assert len(filtered) == 4
+        expected_weight = 1.0 / 7
         for w in filtered.values():
-            assert abs(w - 0.25) < 1e-9
+            assert abs(w - expected_weight) < 1e-9
 
     def test_no_price_data_passes(self):
         """가격 데이터 없는 종목은 필터 통과한다."""


### PR DESCRIPTION
## Summary
- **executor.py**: 리스크 검증을 allocator 스케일링 후로 이동하여 실제 포트폴리오 비중(effective_weights) 기준으로 검증
- **scheduler/main.py + multi_factor.py**: 고정 슬롯 비중 배분 (`1/target_num_stocks`) — 선정 종목이 부족하면 과잉 집중 대신 현금 유지
- **test_scheduler.py**: 변경된 비중 계산에 맞게 테스트 기대값 업데이트

## 변경 배경
1. 기존 리스크 검증은 allocator 스케일링 전 `target_weights` 기준 → ETF 30% 풀에서 개별 종목 33%가 전체 포트폴리오 ~10%임에도 차단되는 문제
2. 동일 비중(`1/len`) 배분 시 7슬롯에 3종목만 선정되면 각 33% → 소규모 자본에서 집중 리스크 과다

## 3자 합의 (Consensus)
| AI | 판정 | 핵심 |
|---|---|---|
| Gemini | 승인 | `execute_integrated_rebalance`와 일관성 확보, 퀀트 표준 방식 |
| Codex | 승인 | 하류 로직 정합성 확인, 관련 테스트 11개 통과 |
| Claude | 승인 | 엣지케이스 가드 확인 완료 |

## Test plan
- [x] TestFilterAffordableSignals 8개 테스트 통과
- [x] TestRiskGuard 테스트 통과
- [x] test_multi_factor.py 전체 통과
- [x] 총 52개 관련 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)