### PR TITLE
장 전 시총=0 캐시 오염 방지: sanity check + 전 거래일 fallback

### DIFF
--- a/src/data/collector.py
+++ b/src/data/collector.py
@@ -363,6 +363,18 @@ def get_all_fundamentals(
         col_order = [c for c in col_order if c in df.columns]
         df = df[col_order]
 
+        # Sanity check: 시가총액이 거의 전부 0이면 장 시작 전 불완전 데이터
+        if "market_cap" in df.columns and len(df) > 0:
+            valid_cap_ratio = (df["market_cap"] > 0).sum() / len(df)
+            if valid_cap_ratio < 0.05:
+                logger.warning(
+                    "펀더멘탈 데이터 불완전: market_cap 유효 비율 %.1f%% (%s). "
+                    "빈 DataFrame 반환.",
+                    valid_cap_ratio * 100,
+                    d,
+                )
+                return pd.DataFrame()
+
         logger.info(f"전 종목 기본 지표 조회 완료: {len(df)}개 종목")
         return df
 

--- a/src/scheduler/main.py
+++ b/src/scheduler/main.py
@@ -2438,8 +2438,24 @@ class TradingBot:
         try:
             today_str = datetime.now(KST).strftime("%Y%m%d")
             strategy_data = self._collect_strategy_data(today_str)
+            data_date = today_str
 
             fund = strategy_data.get("fundamentals")
+            if fund is None or (hasattr(fund, "empty") and fund.empty):
+                # 당일 데이터 불완전 → 전 거래일 fallback
+                prev_day = self.holidays.prev_trading_day(
+                    datetime.now(KST).date()
+                )
+                prev_str = prev_day.strftime("%Y%m%d")
+                logger.info(
+                    "당일(%s) 펀더멘탈 미준비, 전 거래일(%s) fallback",
+                    today_str,
+                    prev_str,
+                )
+                strategy_data = self._collect_strategy_data(prev_str)
+                data_date = prev_str
+                fund = strategy_data.get("fundamentals")
+
             if fund is None or (hasattr(fund, "empty") and fund.empty):
                 logger.warning("실시간 프리뷰: 펀더멘탈 데이터 없음")
                 return None
@@ -2448,7 +2464,7 @@ class TradingBot:
             if strategy is None:
                 return None
 
-            signals = strategy.generate_signals(today_str, strategy_data)
+            signals = strategy.generate_signals(data_date, strategy_data)
             if not signals:
                 return None
 

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -425,3 +425,36 @@ class TestGetAllFundamentals:
 
         assert isinstance(df, pd.DataFrame)
         assert df.empty
+
+    @patch("src.data.collector.pykrx_stock")
+    def test_empty_when_all_market_cap_zero(self, mock_pykrx):
+        """시가총액이 전부 0이면 빈 DataFrame을 반환한다 (장 전 불완전 데이터)."""
+        fund_df = pd.DataFrame(
+            {
+                "BPS": [45000, 30000],
+                "PER": [12.5, 8.0],
+                "PBR": [1.5, 0.8],
+                "EPS": [5600, 3800],
+                "DIV": [2.1, 3.5],
+                "DPS": [1444, 1000],
+            },
+            index=pd.Index(["005930", "000660"], name="티커"),
+        )
+        cap_df = pd.DataFrame(
+            {
+                "종가": [0, 0],
+                "시가총액": [0, 0],
+                "거래량": [0, 0],
+                "거래대금": [0, 0],
+                "상장주식수": [5_969_782_550, 728_002_365],
+            },
+            index=pd.Index(["005930", "000660"], name="티커"),
+        )
+        mock_pykrx.get_market_fundamental.return_value = fund_df
+        mock_pykrx.get_market_cap.return_value = cap_df
+        mock_pykrx.get_market_ticker_name.side_effect = lambda t: "테스트"
+
+        df = get_all_fundamentals("20240102", market="KOSPI")
+
+        assert isinstance(df, pd.DataFrame)
+        assert df.empty, "market_cap 전부 0이면 빈 DataFrame이어야 한다"

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1862,3 +1862,68 @@ class TestMultiFactorScanLimit:
 
         assert not strategy._last_combined_scores.empty
         assert len(strategy._last_combined_scores) > 0
+
+
+# ===================================================================
+# 실시간 시그널 날짜 fallback 테스트
+# ===================================================================
+
+class TestLiveSignalsFallback:
+    """_generate_live_long_term_signals 날짜 fallback 검증."""
+
+    def _make_bot(self):
+        bot = _make_bot_with_flag(True)
+        mock_strategy = MagicMock()
+        mock_strategy.num_stocks = 7
+        mock_strategy._last_combined_scores = pd.Series(dtype=float)
+        bot._strategy = mock_strategy
+        return bot
+
+    @patch("src.scheduler.main.datetime")
+    def test_fallback_to_prev_trading_day(self, mock_dt):
+        """당일 데이터 비어있으면 전 거래일로 fallback한다."""
+        import datetime as dt
+
+        TradingBot = _import_trading_bot()
+        bot = self._make_bot()
+
+        # datetime.now() 설정
+        mock_now = dt.datetime(2026, 3, 9, 8, 31, tzinfo=None)
+        mock_dt.now.return_value = mock_now
+        mock_dt.strptime = dt.datetime.strptime
+
+        # 당일 데이터 → empty, 전 거래일 데이터 → 정상
+        empty_data = {
+            "fundamentals": pd.DataFrame(),
+            "prices": {},
+            "index_prices": pd.Series(dtype=float),
+        }
+        good_fund = pd.DataFrame({
+            "ticker": ["005930", "000660"],
+            "name": ["삼성전자", "SK하이닉스"],
+            "market_cap": [400e12, 90e12],
+        })
+        good_data = {
+            "fundamentals": good_fund,
+            "prices": {},
+            "index_prices": pd.Series(dtype=float),
+        }
+
+        call_count = {"n": 0}
+        def mock_collect(date_str):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return empty_data
+            return good_data
+
+        bot._collect_strategy_data = mock_collect
+        bot.holidays.prev_trading_day = MagicMock(
+            return_value=dt.date(2026, 3, 6)
+        )
+        bot._create_long_term_strategy = MagicMock(return_value=None)
+
+        TradingBot._generate_live_long_term_signals(bot, "multi_factor")
+
+        # 2번 호출: today → prev_trading_day
+        assert call_count["n"] == 2
+        bot.holidays.prev_trading_day.assert_called_once()


### PR DESCRIPTION
## Summary
- **문제**: 장 전(08:31) pykrx가 `market_cap=0` 데이터 반환 → 24h 캐시 오염 → `/balance`, 일일 시뮬레이션, 프리워밍 모두 "시총 200개 수집 불가" 실패
- **수정 1**: `get_all_fundamentals()`에 market_cap 유효비율 < 5% 시 빈 DataFrame 반환 (캐시 저장 방지)
- **수정 2**: `_generate_live_long_term_signals()`에서 당일 데이터 없으면 `prev_trading_day`로 자동 fallback

## Test plan
- [x] `test_empty_when_all_market_cap_zero` — market_cap 전부 0일 때 빈 DF 반환 확인
- [x] `test_fallback_to_prev_trading_day` — 당일 데이터 없을 때 전 거래일 fallback 확인
- [x] 전체 테스트 114 passed, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)