### PR TITLE
리밸런싱 주문 비중 한도 차등 적용 (3자 합의)

### DIFF
--- a/src/execution/executor.py
+++ b/src/execution/executor.py
@@ -138,7 +138,7 @@ class RebalanceExecutor:
         )
         for order_spec in sell_orders:
             order_passed, order_reason = self.risk_guard.check_order(
-                order_spec, portfolio_value
+                order_spec, portfolio_value, is_rebalance=True
             )
             if not order_passed:
                 result["skipped"].append(
@@ -175,7 +175,7 @@ class RebalanceExecutor:
         )
         for order_spec in buy_orders:
             order_passed, order_reason = self.risk_guard.check_order(
-                order_spec, portfolio_value
+                order_spec, portfolio_value, is_rebalance=True
             )
             if not order_passed:
                 result["skipped"].append(

--- a/src/execution/risk_guard.py
+++ b/src/execution/risk_guard.py
@@ -140,7 +140,10 @@ class RiskGuard:
         )
 
     def check_order(
-        self, order: dict, portfolio_value: int
+        self,
+        order: dict,
+        portfolio_value: int,
+        is_rebalance: bool = False,
     ) -> tuple[bool, str]:
         """단일 주문을 검증한다.
 
@@ -148,6 +151,8 @@ class RiskGuard:
             order: 주문 딕셔너리.
                 keys: ticker, side, qty, price (또는 amount).
             portfolio_value: 현재 포트폴리오 총 가치 (원).
+            is_rebalance: 리밸런싱 주문 여부. True이면 check_rebalance에서
+                이미 전체 비중을 검증했으므로 보유 비중 한도를 적용한다.
 
         Returns:
             (통과 여부, 사유) 튜플.
@@ -170,10 +175,24 @@ class RiskGuard:
 
             if order_amount > 0:
                 order_pct = order_amount / portfolio_value
-                if order_pct > self.max_order_pct:
+
+                # 리밸런싱: check_rebalance로 전체 비중 검증 완료 →
+                # 보유 비중 한도(ETF/주식 차등) 적용
+                if is_rebalance:
+                    is_etf = ticker in self.etf_tickers
+                    limit = (
+                        self.max_single_etf_pct
+                        if is_etf
+                        else self.max_single_stock_pct
+                    )
+                else:
+                    limit = self.max_order_pct
+
+                if order_pct > limit:
+                    label = "리밸런싱" if is_rebalance else "단일"
                     reason = (
-                        f"단일 주문 비중 초과: {ticker} "
-                        f"({order_pct:.1%} > {self.max_order_pct:.1%})"
+                        f"{label} 주문 비중 초과: {ticker} "
+                        f"({order_pct:.1%} > {limit:.1%})"
                     )
                     logger.warning("리스크 거절: %s", reason)
                     return False, reason

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -309,6 +309,40 @@ class TestRiskGuard:
             f"max_order_pct 초과 주문이 거부되어야 합니다: {msg}"
         )
 
+    def test_rebalance_order_uses_holding_limit(self):
+        """리밸런싱 주문은 보유 비중 한도를 적용한다."""
+        RiskGuard = _import_risk_guard()
+        # 실전: max_order_pct=5%, max_single_stock_pct=10%
+        rg = RiskGuard(is_live=True)
+
+        # 포트폴리오 130만, 주문 13만 (10%) → 일반주문이면 5% 초과로 거부
+        order = {"ticker": "004990", "amount": 130_000, "side": "buy"}
+        portfolio_value = 1_300_000
+
+        # 일반 주문: 거부
+        passed, _ = rg.check_order(order, portfolio_value, is_rebalance=False)
+        assert passed is False, "일반 주문 10%는 5% 한도 초과로 거부"
+
+        # 리밸런싱 주문: 통과 (10% ≤ 주식 한도 10%)
+        passed, _ = rg.check_order(order, portfolio_value, is_rebalance=True)
+        assert passed is True, "리밸런싱 주문 10%는 보유 한도 10% 이내 통과"
+
+    def test_rebalance_order_etf_uses_etf_limit(self):
+        """리밸런싱 ETF 주문은 ETF 비중 한도를 적용한다."""
+        RiskGuard = _import_risk_guard()
+        rg = RiskGuard(is_live=True, etf_tickers={"132030"})
+
+        # ETF 15% 주문 → 리밸런싱이면 ETF 한도 20% 이내 통과
+        order = {"ticker": "132030", "amount": 195_000, "side": "buy"}
+        portfolio_value = 1_300_000  # 15%
+
+        passed, _ = rg.check_order(order, portfolio_value, is_rebalance=True)
+        assert passed is True, "리밸런싱 ETF 15%는 ETF 한도 20% 이내 통과"
+
+        # 일반 주문: 거부 (15% > 5%)
+        passed, _ = rg.check_order(order, portfolio_value, is_rebalance=False)
+        assert passed is False, "일반 ETF 15%는 5% 초과로 거부"
+
     def test_check_single_stock_limit(self):
         """단일 종목 비중 제한이 동작한다."""
         RiskGuard = _import_risk_guard()


### PR DESCRIPTION
## Summary
- 소규모 포트폴리오(130만원)에서 리밸런싱 매수 주문 8건이 전부 `max_order_pct(5%)` 초과로 스킵되는 긴급 이슈 수정
- `check_order`에 `is_rebalance` 파라미터 추가하여 리밸런싱/일반 주문 차등 한도 적용

## 변경 내용
- **RiskGuard.check_order**: `is_rebalance=True`이면 `max_single_stock_pct(10%)` / `max_single_etf_pct(20%)` 적용
- **executor**: 리밸런싱 매도/매수에서 `is_rebalance=True` 전달
- 일반 주문은 기존 `max_order_pct(5%)` 유지

## Test plan
- [x] execution 테스트 57 passed (리밸런싱 차등 한도 2개 신규 포함)
- [x] 기존 테스트 전부 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)