### PR TITLE
[JAE-64] ETF 로테이션 top-1 종목 가중치 상향 (40% → 50~55%)

### DIFF
--- a/scripts/compare_etf_top1_weight.py
+++ b/scripts/compare_etf_top1_weight.py
@@ -1,0 +1,156 @@
+"""JAE-64: ETF 로테이션 top-1 가중치 비교 시뮬레이션.
+
+equal weight vs top1_weight=0.50 vs top1_weight=0.55
+"""
+
+import sys
+import os
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from src.strategy.etf_rotation import ETFRotationStrategy, ETF_SECTOR_MAP
+
+
+SAFE_ASSET = "439870"
+
+# 섹터별로 다른 3개 ETF (max_same_sector=1 통과 보장)
+#   069500: 국내지수, 360750: 미국지수, 091160: 반도체
+TEST_UNIVERSE = {
+    "069500": "KODEX 200",
+    "360750": "TIGER 미국S&P500",
+    "091160": "KODEX 반도체",
+    SAFE_ASSET: "KODEX 단기채권",
+}
+
+
+def make_prices(annual_returns: dict, n_days: int = 400) -> dict:
+    """ETF 합성 가격 데이터를 생성한다."""
+    np.random.seed(42)
+    dates = pd.date_range("2022-01-03", periods=n_days, freq="B")
+    out = {}
+    for ticker, ann_ret in annual_returns.items():
+        daily = (1 + ann_ret) ** (1 / 252) - 1
+        noise = np.random.normal(0, 0.012, n_days)
+        prices = 10000 * np.cumprod(1 + daily + noise)
+        out[ticker] = pd.DataFrame(
+            {"close": prices, "volume": [1_000_000] * n_days},
+            index=dates,
+        )
+    # 안전자산: 거의 변동 없음
+    out[SAFE_ASSET] = pd.DataFrame(
+        {"close": np.linspace(10000, 10200, n_days), "volume": [1_000_000] * n_days},
+        index=dates,
+    )
+    return out
+
+
+def simulate(top1_weight: float, prices: dict, n_periods: int = 20) -> dict:
+    """월별 리밸런싱 포트폴리오를 시뮬레이션한다."""
+    strategy = ETFRotationStrategy(
+        num_etfs=3,
+        lookback=63,
+        weighting="equal",
+        top1_weight=top1_weight,
+        safe_asset=SAFE_ASSET,
+        etf_universe=TEST_UNIVERSE,
+        abs_momentum=False,
+        max_same_sector=1,
+    )
+
+    risky_tickers = [t for t in TEST_UNIVERSE if t != SAFE_ASSET]
+    all_dates = list(prices[risky_tickers[0]].index)
+    rebal_dates = all_dates[63::21][:n_periods]
+
+    portfolio_value = 100.0
+    returns = []
+
+    for i, date in enumerate(rebal_dates[:-1]):
+        etf_at_date = {t: df[df.index <= date] for t, df in prices.items()}
+        signals = strategy.generate_signals(
+            date.strftime("%Y%m%d"), {"etf_prices": etf_at_date},
+        )
+        next_date = rebal_dates[i + 1]
+
+        period_return = 0.0
+        for ticker, weight in signals.items():
+            if ticker in prices:
+                p_now  = float(prices[ticker].loc[prices[ticker].index <= date, "close"].iloc[-1])
+                p_next = float(prices[ticker].loc[prices[ticker].index <= next_date, "close"].iloc[-1])
+                period_return += weight * (p_next / p_now - 1)
+
+        portfolio_value *= (1 + period_return)
+        returns.append(period_return)
+
+    arr = np.array(returns)
+    n_years = len(arr) / 12
+    cagr = (portfolio_value / 100) ** (1 / max(n_years, 0.01)) - 1
+    sharpe = (arr.mean() / arr.std() * np.sqrt(12)) if arr.std() > 0 else 0
+    cum = np.cumprod(1 + arr) * 100
+    mdd = float(((cum - np.maximum.accumulate(cum)) / np.maximum.accumulate(cum)).min()) * 100
+
+    return {"cagr": cagr * 100, "sharpe_ratio": sharpe, "mdd": mdd}
+
+
+def verify_weight_split():
+    """비중 분배 수식 검증 (3 ETF 선택 시 50/25/25)."""
+    print("\n[비중 분배 검증 — 3섹터 ETF, no abs_momentum]")
+    prices = make_prices({"069500": 0.20, "360750": 0.10, "091160": 0.05})
+
+    for tw in [0.0, 0.50, 0.55]:
+        strategy = ETFRotationStrategy(
+            num_etfs=3, lookback=63, weighting="equal",
+            top1_weight=tw, safe_asset=SAFE_ASSET,
+            etf_universe=TEST_UNIVERSE, abs_momentum=False, max_same_sector=1,
+        )
+        etf_data = {t: df.head(100) for t, df in {**prices,
+            SAFE_ASSET: pd.DataFrame({"close": [10000]*100, "volume": [0]*100},
+                index=pd.date_range("2022-01-03", periods=100, freq="B"))}.items()}
+        signals = strategy.generate_signals("20230101", {"etf_prices": etf_data})
+        total = sum(signals.values())
+        sorted_w = sorted(signals.items(), key=lambda x: x[1], reverse=True)
+        print(f"  top1_weight={tw:.2f}: " +
+              " | ".join(f"{t}={w:.1%}" for t, w in sorted_w) +
+              f"  (합계={total:.3f})")
+
+
+def run_comparison():
+    # 시나리오: top-1이 명확히 우월한 경우 (top-1이 다른 두 ETF보다 2배 이상 수익)
+    prices_bull = make_prices({"069500": 0.30, "360750": 0.10, "091160": 0.08})
+
+    configs = [
+        ("Equal(33/33/33)", 0.0),
+        ("Top1-50(50/25/25)", 0.50),
+        ("Top1-55(55/22.5/22.5)", 0.55),
+    ]
+
+    print(f"\n" + "=" * 68)
+    print("JAE-64: ETF 로테이션 top-1 가중치 비교 시뮬레이션")
+    print("합성 데이터 — 상승장: top-1 +30%/yr, top-2 +10%, top-3 +8%")
+    print("=" * 68)
+    print(f"{'전략':<32} {'CAGR':>8} {'Sharpe':>8} {'MDD':>8}")
+    print("-" * 68)
+
+    results = []
+    for label, tw in configs:
+        r = simulate(top1_weight=tw, prices=prices_bull)
+        results.append((label, tw, r))
+        print(f"{label:<32} {r['cagr']:>7.1f}% {r['sharpe_ratio']:>8.2f} {r['mdd']:>7.1f}%")
+
+    print("=" * 68)
+    baseline = results[0][2]
+    print("\n[Equal 대비 개선폭]")
+    for label, tw, r in results[1:]:
+        dc = r['cagr'] - baseline['cagr']
+        ds = r['sharpe_ratio'] - baseline['sharpe_ratio']
+        dm = r['mdd'] - baseline['mdd']
+        print(f"  {label}: CAGR {'+' if dc>=0 else ''}{dc:.2f}pp, "
+              f"Sharpe {'+' if ds>=0 else ''}{ds:.3f}, "
+              f"MDD {'+' if dm>=0 else ''}{dm:.2f}pp")
+
+    verify_weight_split()
+
+
+if __name__ == "__main__":
+    run_comparison()

--- a/src/strategy/etf_rotation.py
+++ b/src/strategy/etf_rotation.py
@@ -78,6 +78,10 @@ class ETFRotationStrategy(Strategy):
         momentum_cap: 모멘텀 절대 상한 (기본 3.0 = 300%).
             극단적 모멘텀(예: +400%)이 z-score를 왜곡하는 것을 방지.
             0 이하이면 캡 비활성화.
+        top1_weight: top-1 ETF의 초과 비중 (0.0 = 동일가중, 0.5~0.55 권장).
+            0.0보다 크면 1위 ETF가 해당 비율을 가져가고 나머지 ETF가 나눈다.
+            예: num_etfs=3, top1_weight=0.50 → 50%/25%/25%.
+            0.0이면 기존 equal 또는 inverse_vol 방식 그대로.
     """
 
     def __init__(
@@ -90,6 +94,7 @@ class ETFRotationStrategy(Strategy):
         abs_momentum: bool = True,
         max_same_sector: int = 1,
         momentum_cap: float = 3.0,
+        top1_weight: float = 0.0,
     ):
         self.lookback = lookback
         self.num_etfs = num_etfs
@@ -99,11 +104,17 @@ class ETFRotationStrategy(Strategy):
         self.abs_momentum = abs_momentum
         self.max_same_sector = max_same_sector
         self.momentum_cap = momentum_cap
+        self.top1_weight = top1_weight
 
         if weighting not in ("equal", "inverse_vol"):
             raise ValueError(
                 f"지원하지 않는 가중 방식: {weighting}. "
                 "'equal' 또는 'inverse_vol' 중 선택하세요."
+            )
+
+        if not (0.0 <= top1_weight < 1.0):
+            raise ValueError(
+                f"top1_weight는 0.0 이상 1.0 미만이어야 합니다: {top1_weight}"
             )
 
         # 단계적 fallback lookback 목록
@@ -116,7 +127,7 @@ class ETFRotationStrategy(Strategy):
             f"ETFRotationStrategy 초기화: lookback={lookback}, "
             f"num_etfs={num_etfs}, safe_asset={safe_asset}, "
             f"weighting={weighting}, max_same_sector={max_same_sector}, "
-            f"momentum_cap={momentum_cap}, "
+            f"momentum_cap={momentum_cap}, top1_weight={top1_weight}, "
             f"universe={len(self.etf_universe)}개"
         )
 
@@ -418,10 +429,22 @@ class ETFRotationStrategy(Strategy):
             return {}
 
         if self.weighting == "equal":
-            slot_weight = 1.0 / total_slots
-            signals = {t: slot_weight for t in selected_tickers}
-            if safe_asset_count > 0:
-                signals[self.safe_asset] = slot_weight * safe_asset_count
+            if self.top1_weight > 0 and len(selected_tickers) >= 2:
+                # top-1 집중 가중: 1위가 top1_weight, 나머지가 균등 분배
+                risky_slots = len(selected_tickers)
+                risky_portion = risky_slots / total_slots
+                others_weight = (1.0 - self.top1_weight) / (risky_slots - 1)
+                signals = {}
+                for i, t in enumerate(selected_tickers):
+                    base_w = self.top1_weight if i == 0 else others_weight
+                    signals[t] = base_w * risky_portion
+                if safe_asset_count > 0:
+                    signals[self.safe_asset] = safe_asset_count / total_slots
+            else:
+                slot_weight = 1.0 / total_slots
+                signals = {t: slot_weight for t in selected_tickers}
+                if safe_asset_count > 0:
+                    signals[self.safe_asset] = slot_weight * safe_asset_count
         elif self.weighting == "inverse_vol":
             if selected_tickers:
                 risk_weights = self._calculate_inverse_vol_weights(

--- a/src/utils/feature_flags.py
+++ b/src/utils/feature_flags.py
@@ -192,6 +192,7 @@ class FeatureFlags:
                 "etf_rotation_pct": 0.30,
                 "max_same_sector": 1,
                 "momentum_cap": 3.0,
+                "top1_weight": 0.5,
             },
         },
         "daily_simulation": {

--- a/tests/test_etf_rotation.py
+++ b/tests/test_etf_rotation.py
@@ -1280,3 +1280,155 @@ class TestMomentumCap:
         defaults = FeatureFlags.DEFAULT_FLAGS["etf_rotation"]
         assert "momentum_cap" in defaults["config"]
         assert defaults["config"]["momentum_cap"] == 3.0
+
+
+# ===================================================================
+# top1_weight 테스트
+# ===================================================================
+
+class TestTop1Weight:
+    """top1_weight 파라미터 검증."""
+
+    @staticmethod
+    def _make_etf_price(start, end, n_days=100):
+        dates = pd.date_range("2023-01-01", periods=n_days, freq="B")
+        prices = np.linspace(start, end, n_days)
+        return pd.DataFrame({"close": prices, "volume": [1_000_000] * n_days}, index=dates)
+
+    @staticmethod
+    def _make_3sector_universe():
+        """섹터가 서로 다른 3개 ETF 유니버스 (섹터 필터 통과 보장)."""
+        return {
+            "069500": "KODEX 200",       # 국내지수
+            "360750": "TIGER 미국S&P500",  # 미국지수
+            "091160": "KODEX 반도체",      # 반도체
+            "439870": "KODEX 단기채권",
+        }
+
+    def test_default_top1_weight_is_zero(self):
+        """기본 top1_weight는 0.0이다."""
+        s = ETFRotationStrategy()
+        assert s.top1_weight == 0.0
+
+    def test_invalid_top1_weight_raises(self):
+        """top1_weight가 [0, 1) 범위를 벗어나면 ValueError를 발생시킨다."""
+        with pytest.raises(ValueError, match="top1_weight"):
+            ETFRotationStrategy(top1_weight=-0.1)
+        with pytest.raises(ValueError, match="top1_weight"):
+            ETFRotationStrategy(top1_weight=1.0)
+
+    def test_top1_weight_50_gives_50_25_25_split(self):
+        """top1_weight=0.5이면 1위 50%, 2위 25%, 3위 25% 비중이 배분된다."""
+        universe = self._make_3sector_universe()
+        s = ETFRotationStrategy(
+            lookback=60,
+            num_etfs=3,
+            etf_universe=universe,
+            safe_asset="439870",
+            weighting="equal",
+            top1_weight=0.50,
+            abs_momentum=False,
+            max_same_sector=1,
+        )
+
+        etf_prices = {
+            "069500": self._make_etf_price(10000, 13000),  # 1위
+            "360750": self._make_etf_price(10000, 11000),  # 2위
+            "091160": self._make_etf_price(10000, 10500),  # 3위
+        }
+
+        signals = s.generate_signals("20240101", {"etf_prices": etf_prices})
+
+        assert len(signals) == 3
+        sorted_w = sorted(signals.values(), reverse=True)
+        assert abs(sorted_w[0] - 0.50) < 1e-6, f"top-1 비중은 50%여야 함: {sorted_w[0]}"
+        assert abs(sorted_w[1] - 0.25) < 1e-6, f"top-2 비중은 25%여야 함: {sorted_w[1]}"
+        assert abs(sorted_w[2] - 0.25) < 1e-6, f"top-3 비중은 25%여야 함: {sorted_w[2]}"
+        assert abs(sum(signals.values()) - 1.0) < 1e-6
+
+    def test_top1_weight_55_gives_55_225_225_split(self):
+        """top1_weight=0.55이면 1위 55%, 2위/3위 각 22.5% 비중이 배분된다."""
+        universe = self._make_3sector_universe()
+        s = ETFRotationStrategy(
+            lookback=60,
+            num_etfs=3,
+            etf_universe=universe,
+            safe_asset="439870",
+            weighting="equal",
+            top1_weight=0.55,
+            abs_momentum=False,
+            max_same_sector=1,
+        )
+
+        etf_prices = {
+            "069500": self._make_etf_price(10000, 13000),
+            "360750": self._make_etf_price(10000, 11000),
+            "091160": self._make_etf_price(10000, 10500),
+        }
+
+        signals = s.generate_signals("20240101", {"etf_prices": etf_prices})
+
+        sorted_w = sorted(signals.values(), reverse=True)
+        assert abs(sorted_w[0] - 0.55) < 1e-6
+        assert abs(sorted_w[1] - 0.225) < 1e-6
+        assert abs(sorted_w[2] - 0.225) < 1e-6
+
+    def test_top1_weight_zero_gives_equal_weight(self):
+        """top1_weight=0이면 기존 equal weight와 동일하다."""
+        universe = self._make_3sector_universe()
+        s = ETFRotationStrategy(
+            lookback=60,
+            num_etfs=3,
+            etf_universe=universe,
+            safe_asset="439870",
+            weighting="equal",
+            top1_weight=0.0,
+            abs_momentum=False,
+            max_same_sector=1,
+        )
+
+        etf_prices = {
+            "069500": self._make_etf_price(10000, 13000),
+            "360750": self._make_etf_price(10000, 11000),
+            "091160": self._make_etf_price(10000, 10500),
+        }
+
+        signals = s.generate_signals("20240101", {"etf_prices": etf_prices})
+
+        for w in signals.values():
+            assert abs(w - 1 / 3) < 1e-6
+
+    def test_top1_weight_with_safe_asset_replacement(self):
+        """절대모멘텀 필터로 일부 ETF가 안전자산으로 대체될 때 비중이 올바르다."""
+        universe = self._make_3sector_universe()
+        s = ETFRotationStrategy(
+            lookback=60,
+            num_etfs=3,
+            etf_universe=universe,
+            safe_asset="439870",
+            weighting="equal",
+            top1_weight=0.50,
+            abs_momentum=True,
+            max_same_sector=1,
+        )
+
+        etf_prices = {
+            "069500": self._make_etf_price(10000, 13000),   # +30% 양의 모멘텀
+            "360750": self._make_etf_price(10000, 11000),   # +10% 양의 모멘텀
+            "091160": self._make_etf_price(13000, 10500),   # 음의 모멘텀 → safe_asset
+        }
+
+        signals = s.generate_signals("20240101", {"etf_prices": etf_prices})
+
+        # 음의 모멘텀 ETF는 제외, total_slots=3이므로 safe_asset 포함
+        assert sum(signals.values()) == pytest.approx(1.0, abs=1e-6)
+        # 2개 ETF + 안전자산 슬롯 → 총 3슬롯
+        assert "439870" in signals
+
+    def test_feature_flag_has_top1_weight(self):
+        """etf_rotation DEFAULT_FLAGS에 top1_weight가 포함된다."""
+        from src.utils.feature_flags import FeatureFlags
+
+        defaults = FeatureFlags.DEFAULT_FLAGS["etf_rotation"]
+        assert "top1_weight" in defaults["config"]
+        assert defaults["config"]["top1_weight"] == 0.5


### PR DESCRIPTION
## Summary

- `ETFRotationStrategy`에 `top1_weight` 파라미터 추가 (기본 `0.0` = 기존 equal weight, 하위 호환)
- `top1_weight=0.50` → 1위 **50%** / 2위 25% / 3위 25%
- `top1_weight=0.55` → 1위 **55%** / 2위 22.5% / 3위 22.5%
- `FeatureFlags.DEFAULT_FLAGS["etf_rotation"]["config"]["top1_weight"] = 0.5` 로 기본값 설정
- 신규 테스트 7개 추가 (`TestTop1Weight`)

## Backtest 비교 결과 (합성 데이터, top-1 연 +30%)

| 전략 | CAGR | Sharpe | MDD |
|------|------|--------|-----|
| Equal(33/33/33) | 35.5% | 2.51 | -4.2% |
| Top1-50(50/25/25) | 35.6% | 2.36 | -4.2% |
| Top1-55(55/22.5/22.5) | 35.7% | 2.28 | -4.6% |

> 수학적 검증 완료: 비중 합계 1.0, 50/25/25 & 55/22.5/22.5 분배 정확.
> 실거래 데이터 장기 백테스트는 캐시 확보 후 별도 실행 예정.

## 변경 범위

- `src/strategy/etf_rotation.py` — `top1_weight` 파라미터 + weighting 로직
- `src/utils/feature_flags.py` — DEFAULT_FLAGS 업데이트
- `tests/test_etf_rotation.py` — TestTop1Weight 클래스 (7개 테스트)
- `scripts/compare_etf_top1_weight.py` — 비교 스크립트

## Test plan

- [x] `TestTop1Weight` 7개 신규 테스트 통과
- [x] 기존 `TestMomentumCap`, `TestSectorFilter`, `TestETFRotationSignals` 등 54개 통과
- [x] `top1_weight=0` 시 기존 equal weight와 동일 결과 검증

Closes JAE-64

🤖 Generated with [Claude Code](https://claude.com/claude-code)