### PR TITLE
feat(config): JAE-66 ETF/장기 풀 비중 70/30 → 60/40 1차 이행

### DIFF
--- a/data/portfolio_allocation.json
+++ b/data/portfolio_allocation.json
@@ -1,10 +1,10 @@
 {
   "version": 1,
-  "updated_at": "2026-03-04T09:05:36",
+  "updated_at": "2026-05-29T09:00:00",
   "config": {
-    "long_term_pct": 0.7,
+    "long_term_pct": 0.6,
     "short_term_pct": 0.0,
-    "etf_rotation_pct": 0.3,
+    "etf_rotation_pct": 0.4,
     "soft_cap_mode": true
   },
   "positions": {

--- a/src/utils/feature_flags.py
+++ b/src/utils/feature_flags.py
@@ -189,7 +189,7 @@ class FeatureFlags:
                 "n_select": 3,
                 "rebalance_freq": "monthly",
                 "volatility_target": 0.0,
-                "etf_rotation_pct": 0.30,
+                "etf_rotation_pct": 0.40,
                 "max_same_sector": 1,
                 "momentum_cap": 3.0,
                 "top1_weight": 0.5,


### PR DESCRIPTION
## 배경

[JAE-60](/JAE/issues/JAE-60) 파생 + 보드 승인 완료 (approval 3d591ac4-7a9a-497e-b5ed-836430b41aaa).
[JAE-62](/JAE/issues/JAE-62) 백테스트에서 ETF 풀이 Sharpe 1.58로 장기 풀(-0.66)을 압도하는 결과에 따라 단계적 비중 상향 1차 이행.

## 변경 사항

| 파일 | 변경 내용 |
|------|-----------|
| `data/portfolio_allocation.json` | `long_term_pct` 0.7 → 0.6, `etf_rotation_pct` 0.3 → 0.4 |
| `src/utils/feature_flags.py` | `DEFAULT_FLAGS["etf_rotation"]["config"]["etf_rotation_pct"]` 0.30 → 0.40 |

> `data/feature_flags.json`은 `.gitignore` 대상 런타임 파일이므로 PR에 포함되지 않음.
> 배포 후 systemd 재시작 시 `portfolio_allocation.json` 값(0.4)이 `PortfolioAllocator._load()`에서 자동 적용됨.

## 검증

- `tests/test_portfolio_allocator.py`: 68 passed ✅
- `tests/test_feature_flags.py`: 58 passed ✅

## 3개월 후 리뷰 계획

2026-09-01 전후 풀별 Sharpe 재평가 → 결과에 따라 50/50 또는 40/60 추가 이행 결정.