### PR TITLE
feat(alert): JAE-83 이메일·GitHub push 스크립트 다중 파일 지원

### DIFF
--- a/scripts/email_weekly_report.py
+++ b/scripts/email_weekly_report.py
@@ -1,7 +1,9 @@
 """주간 리포트 마크다운 파일을 HTML로 변환해 이메일로 발송한다.
 
 사용:
-    python scripts/email_weekly_report.py <markdown_file_path>
+    python scripts/email_weekly_report.py <markdown_file_path> [<markdown_file_path> ...]
+
+여러 파일을 전달하면 입력 순서대로 `---` 구분선으로 연결해 1통의 메일로 발송한다.
 
 요건:
 - SMTP_HOST, SMTP_SENDER, SMTP_PASSWORD, SMTP_RECIPIENTS 환경변수 설정 (.env)
@@ -17,7 +19,7 @@ import re
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import Optional
+from typing import Iterable, Optional, Sequence, Union
 from zoneinfo import ZoneInfo
 
 import markdown as md_lib  # type: ignore[import-not-found]
@@ -34,6 +36,7 @@ logger = get_logger(__name__)
 
 _DATE_RE = re.compile(r"(\d{4}-\d{2}-\d{2})")
 _KST = ZoneInfo("Asia/Seoul")
+_FILE_SEPARATOR = "\n\n---\n\n"
 
 _HTML_STYLE = """
 <style>
@@ -104,24 +107,52 @@ def _build_subject(report_date: Optional[str]) -> str:
     return f"[주간 리포트] {date_str} 밸류체인 분석"
 
 
-def send_weekly_report(report_path: Path) -> bool:
-    """주간 리포트 마크다운 파일을 읽어 이메일로 발송한다.
+def _combine_markdown(paths: Sequence[Path]) -> str:
+    """전달된 파일을 입력 순서대로 `---` 구분선으로 연결한다.
+
+    존재하지 않는 파일은 건너뛰고 경고 로그만 남긴다.
+    """
+    chunks: list[str] = []
+    for path in paths:
+        if not path.is_file():
+            logger.warning("리포트 파일 누락 — 건너뜁니다: %s", path)
+            continue
+        chunks.append(path.read_text(encoding="utf-8"))
+    return _FILE_SEPARATOR.join(chunks)
+
+
+def send_weekly_report(
+    report_paths: Union[Path, str, Iterable[Union[Path, str]]],
+) -> bool:
+    """주간 리포트 마크다운 파일(들)을 읽어 이메일로 발송한다.
 
     Args:
-        report_path: 마크다운 리포트 파일 경로.
+        report_paths: 단일 경로 또는 경로 시퀀스. 시퀀스이면 입력 순서대로 연결해
+            한 통의 메일로 발송한다.
 
     Returns:
         발송 성공 시 True, 미설정/실패/파일 부재 시 False.
         예외는 던지지 않는다 (graceful degradation).
     """
-    path = Path(report_path)
-    if not path.is_file():
-        logger.error("리포트 파일을 찾을 수 없습니다: %s", path)
+    if isinstance(report_paths, (str, Path)):
+        paths = [Path(report_paths)]
+    else:
+        paths = [Path(p) for p in report_paths]
+
+    if not paths:
+        logger.error("리포트 파일이 지정되지 않았습니다.")
         return False
 
-    markdown_text = path.read_text(encoding="utf-8")
-    html_body = render_html(markdown_text)
-    subject = _build_subject(extract_report_date(path))
+    existing = [p for p in paths if p.is_file()]
+    if not existing:
+        logger.error(
+            "리포트 파일을 찾을 수 없습니다: %s", ", ".join(str(p) for p in paths)
+        )
+        return False
+
+    combined_md = _combine_markdown(paths)
+    html_body = render_html(combined_md)
+    subject = _build_subject(extract_report_date(existing[0]))
 
     notifier = EmailNotifier()
     if not notifier.is_configured():
@@ -136,12 +167,16 @@ def send_weekly_report(report_path: Path) -> bool:
 
 def main(argv: Optional[list[str]] = None) -> int:
     parser = argparse.ArgumentParser(
-        description="주간 리포트 마크다운 파일을 이메일로 발송한다."
+        description="주간 리포트 마크다운 파일(들)을 이메일로 발송한다."
     )
-    parser.add_argument("report_path", help="마크다운 리포트 파일 경로")
+    parser.add_argument(
+        "report_paths",
+        nargs="+",
+        help="마크다운 리포트 파일 경로 (여러 개 전달 가능, 입력 순서대로 연결)",
+    )
     args = parser.parse_args(argv)
 
-    success = send_weekly_report(Path(args.report_path))
+    success = send_weekly_report([Path(p) for p in args.report_paths])
     return 0 if success else 1
 
 

--- a/scripts/push_weekly_report_to_github.py
+++ b/scripts/push_weekly_report_to_github.py
@@ -1,7 +1,10 @@
 """주간 리포트 마크다운을 별도 GitHub 리서치 레포에 자동 push 한다.
 
 사용:
-    python scripts/push_weekly_report_to_github.py <markdown_file_path>
+    python scripts/push_weekly_report_to_github.py <markdown_file_path> [<markdown_file_path> ...]
+
+여러 파일을 전달하면 각 파일을 원본 파일명 그대로 `reports/YYYY/`에 복사하고
+README 인덱스에 일자별 그룹으로 추가한 뒤 1개 커밋으로 push 한다.
 
 요건 (.env):
 - GITHUB_TOKEN          : Personal Access Token (repo write 권한)
@@ -14,8 +17,8 @@
 미설정·실패 시 graceful degradation: 예외를 던지지 않고 경고 로그만 남긴 뒤 False 반환.
 
 레포 구조:
-    reports/YYYY/YYYY-MM-DD-weekly-report.md
-    README.md  (날짜 역순 인덱스 자동 갱신)
+    reports/YYYY/<원본 파일명>     # 예: 2026-05-30-weekly-sector-ai.md
+    README.md                      # 일자별 그룹 인덱스 자동 갱신
 """
 
 from __future__ import annotations
@@ -26,9 +29,10 @@ import re
 import shutil
 import subprocess
 import sys
+from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
-from typing import Optional, Sequence
+from typing import Iterable, Optional, Sequence, Union
 from zoneinfo import ZoneInfo
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[1]
@@ -46,6 +50,8 @@ _DEFAULT_CACHE = Path.home() / ".cache" / "quant-research-repo"
 _DEFAULT_BRANCH = "main"
 _INDEX_BEGIN = "<!-- WEEKLY-INDEX:BEGIN -->"
 _INDEX_END = "<!-- WEEKLY-INDEX:END -->"
+_REPORT_GLOB = "*-weekly-*.md"
+_SUMMARY_LABEL = "종합"
 
 
 class GithubPushError(RuntimeError):
@@ -57,6 +63,21 @@ def _extract_report_date(path: Path) -> str:
     if match:
         return match.group(1)
     return datetime.now(_KST).strftime("%Y-%m-%d")
+
+
+def _label_for_filename(filename: str, date_str: str) -> str:
+    """`2026-05-30-weekly-sector-ai.md` → `sector-ai`, `*-weekly-valuechain-report.md` → `종합`."""
+    stem = filename
+    if stem.endswith(".md"):
+        stem = stem[:-3]
+    prefix = f"{date_str}-weekly-"
+    if stem.startswith(prefix):
+        suffix = stem[len(prefix):]
+    else:
+        suffix = stem
+    if not suffix or suffix in {"report", "valuechain-report"}:
+        return _SUMMARY_LABEL
+    return suffix
 
 
 def _run_git(
@@ -113,43 +134,81 @@ def _sync_repo(cache_dir: Path, repo: str, token: str, branch: str) -> None:
 
 
 def _copy_report(report_path: Path, repo_root: Path, report_date: str) -> Path:
+    """입력 파일을 원본 파일명을 유지한 채 `reports/YYYY/`로 복사한다."""
     year = report_date.split("-")[0]
     dest_dir = repo_root / "reports" / year
     dest_dir.mkdir(parents=True, exist_ok=True)
-    dest = dest_dir / f"{report_date}-weekly-report.md"
+    dest = dest_dir / report_path.name
     shutil.copyfile(report_path, dest)
     return dest
 
 
 def _collect_existing_reports(repo_root: Path) -> list[tuple[str, Path]]:
-    """`reports/YYYY/YYYY-MM-DD-weekly-report.md` 패턴을 모두 수집한다."""
+    """`reports/YYYY/*-weekly-*.md` 패턴(섹터별 + 종합 리포트)을 모두 수집한다."""
     reports: list[tuple[str, Path]] = []
     base = repo_root / "reports"
     if not base.is_dir():
         return reports
-    for path in base.rglob("*-weekly-report.md"):
+    for path in base.rglob(_REPORT_GLOB):
         m = _DATE_RE.search(path.name)
         if not m:
             continue
         reports.append((m.group(1), path.relative_to(repo_root)))
-    reports.sort(key=lambda item: item[0], reverse=True)
+    # 날짜 내림차순, 같은 날짜 안에서는 종합(`*-weekly-report.md`/`valuechain-report`)이 마지막,
+    # 섹터 파일은 알파벳 순으로 정렬해 결정론적인 README 를 만든다.
+    def _sort_key(item: tuple[str, Path]) -> tuple[str, int, str]:
+        date_str, rel = item
+        label = _label_for_filename(rel.name, date_str)
+        is_summary = 1 if label == _SUMMARY_LABEL else 0
+        return (date_str, is_summary, label)
+
+    reports.sort(key=_sort_key, reverse=True)
     return reports
 
 
 def _render_index_section(reports: Sequence[tuple[str, Path]]) -> str:
+    """README 인덱스 블록 본문을 만든다.
+
+    여러 파일이 같은 날짜에 묶여있으면 들여쓰기 sublist 로 표시하고,
+    하루에 한 파일이면 단일 라인으로 표시해 기존 단일 종합 리포트 호환을 유지한다.
+    """
     if not reports:
         return f"{_INDEX_BEGIN}\n_아직 업로드된 리포트가 없습니다._\n{_INDEX_END}"
-    lines = [_INDEX_BEGIN, ""]
-    current_year: Optional[str] = None
+
+    # 연도 → 날짜 그룹화. reports 는 이미 (date desc, label asc, summary last) 정렬됨.
+    by_year: "dict[str, dict[str, list[Path]]]" = defaultdict(lambda: defaultdict(list))
+    year_order: list[str] = []
+    date_order_by_year: "dict[str, list[str]]" = defaultdict(list)
     for date_str, rel_path in reports:
         year = date_str.split("-")[0]
-        if year != current_year:
-            if current_year is not None:
-                lines.append("")
-            lines.append(f"### {year}")
-            current_year = year
-        link = rel_path.as_posix()
-        lines.append(f"- [{date_str}]({link})")
+        if year not in year_order:
+            year_order.append(year)
+        if date_str not in date_order_by_year[year]:
+            date_order_by_year[year].append(date_str)
+        by_year[year][date_str].append(rel_path)
+
+    lines = [_INDEX_BEGIN, ""]
+    for idx, year in enumerate(year_order):
+        if idx > 0:
+            lines.append("")
+        lines.append(f"### {year}")
+        for date_str in date_order_by_year[year]:
+            paths = by_year[year][date_str]
+            if len(paths) == 1:
+                lines.append(f"- [{date_str}]({paths[0].as_posix()})")
+            else:
+                lines.append(f"- {date_str}")
+                # 섹터 파일이 먼저, 종합(`종합`)이 마지막으로 오도록 정렬
+                ordered = sorted(
+                    paths,
+                    key=lambda p: (
+                        1 if _label_for_filename(p.name, date_str) == _SUMMARY_LABEL else 0,
+                        _label_for_filename(p.name, date_str),
+                    ),
+                )
+                for path in ordered:
+                    label = _label_for_filename(path.name, date_str)
+                    lines.append(f"  - [{label}]({path.as_posix()})")
     lines.append("")
     lines.append(_INDEX_END)
     return "\n".join(lines)
@@ -185,7 +244,10 @@ def _has_changes(repo_root: Path) -> bool:
 
 
 def _commit_and_push(
-    repo_root: Path, branch: str, report_date: str
+    repo_root: Path,
+    branch: str,
+    report_date: str,
+    file_count: int,
 ) -> bool:
     if not _has_changes(repo_root):
         logger.info("변경 사항 없음 — push 생략 (date=%s)", report_date)
@@ -201,29 +263,44 @@ def _commit_and_push(
         env.setdefault("GIT_AUTHOR_EMAIL", author_email)
         env.setdefault("GIT_COMMITTER_EMAIL", author_email)
 
+    if file_count > 1:
+        message = f"chore(weekly): {report_date} 주간 리포트 업로드 ({file_count}개 파일)"
+    else:
+        message = f"chore(weekly): {report_date} 주간 리포트 업로드"
+
     _run_git(["add", "-A"], cwd=repo_root, env=env)
-    _run_git(
-        ["commit", "-m", f"chore(weekly): {report_date} 주간 리포트 업로드"],
-        cwd=repo_root,
-        env=env,
-    )
+    _run_git(["commit", "-m", message], cwd=repo_root, env=env)
     _run_git(["push", "origin", branch], cwd=repo_root, env=env)
     return True
 
 
-def push_weekly_report(report_path: Path) -> bool:
-    """주간 리포트 마크다운을 GitHub 리서치 레포에 업로드한다.
+def push_weekly_report(
+    report_paths: Union[Path, str, Iterable[Union[Path, str]]],
+) -> bool:
+    """주간 리포트 마크다운 파일(들)을 GitHub 리서치 레포에 업로드한다.
 
     Args:
-        report_path: 업로드할 마크다운 파일 경로.
+        report_paths: 단일 경로 또는 경로 시퀀스. 시퀀스이면 각 파일을 원본 파일명 그대로
+            `reports/YYYY/`에 복사한 뒤 1개 커밋으로 push 한다.
 
     Returns:
         성공 시 True, 미설정/파일 부재/실패 시 False.
         예외를 던지지 않는다.
     """
-    path = Path(report_path)
-    if not path.is_file():
-        logger.error("리포트 파일을 찾을 수 없습니다: %s", path)
+    if isinstance(report_paths, (str, Path)):
+        paths: list[Path] = [Path(report_paths)]
+    else:
+        paths = [Path(p) for p in report_paths]
+
+    if not paths:
+        logger.error("리포트 파일이 지정되지 않았습니다.")
+        return False
+
+    missing = [p for p in paths if not p.is_file()]
+    if missing:
+        logger.error(
+            "리포트 파일을 찾을 수 없습니다: %s", ", ".join(str(p) for p in missing)
+        )
         return False
 
     token = os.environ.get("GITHUB_TOKEN", "").strip()
@@ -242,14 +319,17 @@ def push_weekly_report(report_path: Path) -> bool:
     cache_env = os.environ.get("GITHUB_RESEARCH_CACHE", "").strip()
     cache_dir = Path(cache_env).expanduser() if cache_env else _DEFAULT_CACHE
 
-    report_date = _extract_report_date(path)
+    # 커밋 메시지·README 그룹핑에 쓰는 대표 날짜는 첫 번째 파일 기준.
+    report_date = _extract_report_date(paths[0])
 
     try:
         _sync_repo(cache_dir, repo, token, branch)
-        _copy_report(path, cache_dir, report_date)
+        for path in paths:
+            individual_date = _extract_report_date(path)
+            _copy_report(path, cache_dir, individual_date)
         reports = _collect_existing_reports(cache_dir)
         _update_readme(cache_dir, reports)
-        _commit_and_push(cache_dir, branch, report_date)
+        _commit_and_push(cache_dir, branch, report_date, file_count=len(paths))
     except GithubPushError as exc:
         logger.error("GitHub push 실패: %s", exc)
         return False
@@ -258,22 +338,27 @@ def push_weekly_report(report_path: Path) -> bool:
         return False
 
     logger.info(
-        "주간 리포트 GitHub 업로드 완료: repo=%s branch=%s date=%s",
+        "주간 리포트 GitHub 업로드 완료: repo=%s branch=%s date=%s files=%d",
         repo,
         branch,
         report_date,
+        len(paths),
     )
     return True
 
 
 def main(argv: Optional[list[str]] = None) -> int:
     parser = argparse.ArgumentParser(
-        description="주간 리포트 마크다운을 GitHub 리서치 레포에 push 한다."
+        description="주간 리포트 마크다운 파일(들)을 GitHub 리서치 레포에 push 한다."
     )
-    parser.add_argument("report_path", help="마크다운 리포트 파일 경로")
+    parser.add_argument(
+        "report_paths",
+        nargs="+",
+        help="마크다운 리포트 파일 경로 (여러 개 전달 가능, 원본 파일명 유지)",
+    )
     args = parser.parse_args(argv)
 
-    success = push_weekly_report(Path(args.report_path))
+    success = push_weekly_report([Path(p) for p in args.report_paths])
     return 0 if success else 1
 
 

--- a/tests/test_email_weekly_report.py
+++ b/tests/test_email_weekly_report.py
@@ -1,6 +1,7 @@
 """scripts/email_weekly_report.py 헬퍼 테스트.
 
-마크다운→HTML 변환, 이메일 제목 형식, SMTP 미설정 시 graceful degradation을 검증한다.
+마크다운→HTML 변환, 이메일 제목 형식, 다중 파일 연결,
+SMTP 미설정 시 graceful degradation을 검증한다.
 """
 
 from __future__ import annotations
@@ -142,4 +143,82 @@ class TestSendWeeklyReport:
     def test_returns_false_when_file_missing(self, tmp_path):
         missing = tmp_path / "missing.md"
         result = send_weekly_report(missing)
+        assert result is False
+
+
+class TestMultiFile:
+    def test_concatenates_files_in_input_order_with_separator(self, tmp_path):
+        first = tmp_path / "2026-05-30-weekly-sector-summary.md"
+        second = tmp_path / "2026-05-30-weekly-sector-ai.md"
+        third = tmp_path / "2026-05-30-weekly-valuechain-report.md"
+        first.write_text("# 섹터 요약\n\n핵심 메시지", encoding="utf-8")
+        second.write_text("# AI 섹터\n\nNVDA 기반", encoding="utf-8")
+        third.write_text("# 밸류체인\n\n종합 분석", encoding="utf-8")
+
+        fake_notifier = MagicMock()
+        fake_notifier.is_configured.return_value = True
+        fake_notifier.send_html_report.return_value = True
+
+        with patch(
+            "scripts.email_weekly_report.EmailNotifier",
+            return_value=fake_notifier,
+        ):
+            result = send_weekly_report([first, second, third])
+
+        assert result is True
+        args = fake_notifier.send_html_report.call_args.args
+        kwargs = fake_notifier.send_html_report.call_args.kwargs
+        html_body = kwargs.get("html") or args[0]
+        # 세 본문이 모두 결합됐고 입력 순서대로 등장한다
+        assert html_body.index("섹터 요약") < html_body.index("AI 섹터")
+        assert html_body.index("AI 섹터") < html_body.index("밸류체인")
+        # `---` 마크다운 구분선은 HTML <hr> 로 렌더링된다
+        assert "<hr" in html_body
+
+    def test_subject_uses_first_existing_file_date(self, tmp_path):
+        first = tmp_path / "2026-05-30-weekly-sector-summary.md"
+        second = tmp_path / "2026-05-30-weekly-sector-ai.md"
+        first.write_text("# A", encoding="utf-8")
+        second.write_text("# B", encoding="utf-8")
+
+        fake_notifier = MagicMock()
+        fake_notifier.is_configured.return_value = True
+        fake_notifier.send_html_report.return_value = True
+
+        with patch(
+            "scripts.email_weekly_report.EmailNotifier",
+            return_value=fake_notifier,
+        ):
+            send_weekly_report([first, second])
+
+        args = fake_notifier.send_html_report.call_args.args
+        kwargs = fake_notifier.send_html_report.call_args.kwargs
+        subject = kwargs.get("subject") or args[1]
+        assert subject == "[주간 리포트] 2026-05-30 밸류체인 분석"
+
+    def test_skips_missing_files_but_sends_remaining(self, tmp_path):
+        present = tmp_path / "2026-05-30-weekly-sector-ai.md"
+        present.write_text("# 있는 파일", encoding="utf-8")
+        missing = tmp_path / "2026-05-30-weekly-sector-missing.md"
+
+        fake_notifier = MagicMock()
+        fake_notifier.is_configured.return_value = True
+        fake_notifier.send_html_report.return_value = True
+
+        with patch(
+            "scripts.email_weekly_report.EmailNotifier",
+            return_value=fake_notifier,
+        ):
+            result = send_weekly_report([present, missing])
+
+        assert result is True
+        args = fake_notifier.send_html_report.call_args.args
+        kwargs = fake_notifier.send_html_report.call_args.kwargs
+        html_body = kwargs.get("html") or args[0]
+        assert "있는 파일" in html_body
+
+    def test_returns_false_when_all_files_missing(self, tmp_path):
+        result = send_weekly_report(
+            [tmp_path / "a.md", tmp_path / "b.md"]
+        )
         assert result is False

--- a/tests/test_push_weekly_report_to_github.py
+++ b/tests/test_push_weekly_report_to_github.py
@@ -1,7 +1,7 @@
 """scripts/push_weekly_report_to_github.py 헬퍼 테스트.
 
 GitHub 토큰/레포 환경변수 검증, README 인덱스 렌더링, graceful degradation,
-git 커맨드 시퀀스(클론/리셋/커밋/푸시)를 mock 으로 검증한다.
+git 커맨드 시퀀스(클론/리셋/커밋/푸시) 및 다중 파일 업로드를 mock 으로 검증한다.
 """
 
 from __future__ import annotations
@@ -37,6 +37,26 @@ def report_md(tmp_path: Path) -> Path:
     return path
 
 
+@pytest.fixture
+def sector_reports(tmp_path: Path) -> list[Path]:
+    """JAE-83 표준 섹터 파일 셋트 — summary 먼저, valuechain 마지막."""
+    names = [
+        "2026-05-30-weekly-sector-summary.md",
+        "2026-05-30-weekly-sector-ai.md",
+        "2026-05-30-weekly-sector-physical-ai.md",
+        "2026-05-30-weekly-sector-energy.md",
+        "2026-05-30-weekly-sector-game.md",
+        "2026-05-30-weekly-sector-other.md",
+        "2026-05-30-weekly-valuechain-report.md",
+    ]
+    paths: list[Path] = []
+    for name in names:
+        p = tmp_path / name
+        p.write_text(f"# {name}", encoding="utf-8")
+        paths.append(p)
+    return paths
+
+
 class TestExtractReportDate:
     def test_uses_filename_date(self, tmp_path: Path) -> None:
         path = tmp_path / "2026-05-30-weekly-report.md"
@@ -70,6 +90,24 @@ class TestReadmeRendering:
         assert out.index("### 2026") < out.index("### 2025"), "최신 연도가 먼저 와야 한다"
         assert out.index("2026-05-30") < out.index("2026-05-23")
         assert "reports/2026/2026-05-30-weekly-report.md" in out
+
+    def test_render_index_groups_multiple_files_per_date(self) -> None:
+        reports = [
+            ("2026-05-30", Path("reports/2026/2026-05-30-weekly-sector-ai.md")),
+            ("2026-05-30", Path("reports/2026/2026-05-30-weekly-sector-energy.md")),
+            ("2026-05-30", Path("reports/2026/2026-05-30-weekly-valuechain-report.md")),
+            ("2026-05-23", Path("reports/2026/2026-05-23-weekly-valuechain-report.md")),
+        ]
+        out = _render_index_section(reports)
+        # 같은 날짜의 여러 파일은 sublist 로 표시
+        assert "- 2026-05-30" in out
+        assert "[sector-ai](reports/2026/2026-05-30-weekly-sector-ai.md)" in out
+        assert "[sector-energy](reports/2026/2026-05-30-weekly-sector-energy.md)" in out
+        assert "[종합](reports/2026/2026-05-30-weekly-valuechain-report.md)" in out
+        # 종합이 같은 날 sector 들 뒤에 위치
+        assert out.index("[sector-ai]") < out.index("[종합]")
+        # 단일 파일 날짜는 기존처럼 한 라인
+        assert "- [2026-05-23](reports/2026/2026-05-23-weekly-valuechain-report.md)" in out
 
     def test_update_readme_creates_new_when_missing(self, tmp_path: Path) -> None:
         reports = [("2026-05-30", Path("reports/2026/2026-05-30-weekly-report.md"))]
@@ -116,6 +154,21 @@ class TestCollectExistingReports:
         out = _collect_existing_reports(tmp_path)
         assert [d for d, _ in out] == ["2026-05-30", "2025-12-29"]
 
+    def test_collects_sector_files_with_weekly_pattern(self, tmp_path: Path) -> None:
+        (tmp_path / "reports" / "2026").mkdir(parents=True)
+        for name in [
+            "2026-05-30-weekly-sector-ai.md",
+            "2026-05-30-weekly-sector-energy.md",
+            "2026-05-30-weekly-valuechain-report.md",
+        ]:
+            (tmp_path / "reports" / "2026" / name).write_text("x", encoding="utf-8")
+
+        out = _collect_existing_reports(tmp_path)
+        names = [path.name for _, path in out]
+        assert "2026-05-30-weekly-sector-ai.md" in names
+        assert "2026-05-30-weekly-sector-energy.md" in names
+        assert "2026-05-30-weekly-valuechain-report.md" in names
+
 
 class TestGracefulDegradation:
     def test_returns_false_when_token_missing(
@@ -145,6 +198,15 @@ class TestGracefulDegradation:
         monkeypatch.setenv("GITHUB_TOKEN", "ghp_x")
         monkeypatch.setenv("GITHUB_RESEARCH_REPO", "owner/repo")
         assert push_weekly_report(tmp_path / "missing.md") is False
+
+    def test_returns_false_when_any_file_in_list_missing(
+        self, report_md: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_x")
+        monkeypatch.setenv("GITHUB_RESEARCH_REPO", "owner/repo")
+        assert (
+            push_weekly_report([report_md, tmp_path / "missing.md"]) is False
+        )
 
 
 def _make_fake_git_runner(cache_dir: Path):
@@ -186,7 +248,8 @@ class TestFullFlow:
             result = push_weekly_report(report_md)
 
         assert result is True
-        copied = cache_dir / "reports" / "2026" / "2026-05-30-weekly-report.md"
+        # 원본 파일명을 그대로 유지
+        copied = cache_dir / "reports" / "2026" / "2026-05-30-weekly-valuechain-report.md"
         assert copied.is_file()
         assert copied.read_text(encoding="utf-8") == SAMPLE_MD
 
@@ -284,3 +347,74 @@ class TestFullFlow:
             result = push_weekly_report(report_md)
 
         assert result is False
+
+
+class TestMultiFileUpload:
+    def test_copies_all_files_with_original_names(
+        self,
+        sector_reports: list[Path],
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        cache_dir = tmp_path / "cache" / "quant-research-repo"
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_secret")
+        monkeypatch.setenv("GITHUB_RESEARCH_REPO", "wogus3314/quant-research")
+        monkeypatch.setenv("GITHUB_RESEARCH_CACHE", str(cache_dir))
+
+        history, fake_run = _make_fake_git_runner(cache_dir)
+        with patch("scripts.push_weekly_report_to_github.subprocess.run", side_effect=fake_run):
+            result = push_weekly_report(sector_reports)
+
+        assert result is True
+        for src in sector_reports:
+            copied = cache_dir / "reports" / "2026" / src.name
+            assert copied.is_file(), f"missing: {copied}"
+            assert copied.read_text(encoding="utf-8") == src.read_text(encoding="utf-8")
+
+        # README 에 sublist 인덱스가 들어갔는지
+        readme = (cache_dir / "README.md").read_text(encoding="utf-8")
+        assert "- 2026-05-30" in readme
+        assert "[종합]" in readme
+        assert "[sector-ai]" in readme
+
+    def test_commit_message_includes_file_count_when_multi(
+        self,
+        sector_reports: list[Path],
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        cache_dir = tmp_path / "cache" / "quant-research-repo"
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_secret")
+        monkeypatch.setenv("GITHUB_RESEARCH_REPO", "wogus3314/quant-research")
+        monkeypatch.setenv("GITHUB_RESEARCH_CACHE", str(cache_dir))
+
+        history, fake_run = _make_fake_git_runner(cache_dir)
+        with patch("scripts.push_weekly_report_to_github.subprocess.run", side_effect=fake_run):
+            push_weekly_report(sector_reports)
+
+        commits = [cmd for cmd in history if cmd[1] == "commit"]
+        assert commits, "commit 호출이 있어야 한다"
+        message = commits[0][commits[0].index("-m") + 1]
+        assert "2026-05-30" in message
+        assert f"{len(sector_reports)}개 파일" in message
+
+    def test_single_file_commit_message_unchanged(
+        self,
+        report_md: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        cache_dir = tmp_path / "cache" / "quant-research-repo"
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_secret")
+        monkeypatch.setenv("GITHUB_RESEARCH_REPO", "wogus3314/quant-research")
+        monkeypatch.setenv("GITHUB_RESEARCH_CACHE", str(cache_dir))
+
+        history, fake_run = _make_fake_git_runner(cache_dir)
+        with patch("scripts.push_weekly_report_to_github.subprocess.run", side_effect=fake_run):
+            push_weekly_report(report_md)
+
+        commits = [cmd for cmd in history if cmd[1] == "commit"]
+        message = commits[0][commits[0].index("-m") + 1]
+        # 단일 파일은 (n개 파일) suffix 없이 기존 메시지 유지
+        assert "개 파일" not in message
+        assert message == "chore(weekly): 2026-05-30 주간 리포트 업로드"


### PR DESCRIPTION
## Summary
- `scripts/email_weekly_report.py` 에 `nargs='+'` 다중 파일 지원 추가. 입력 순서대로 `---` 구분선으로 연결해 1통의 메일로 발송. 제목은 첫 파일의 날짜 사용.
- `scripts/push_weekly_report_to_github.py` 에 다중 파일 지원 추가. 원본 파일명 유지하며 `reports/YYYY/` 에 복사. README 인덱스는 날짜별 sublist 로 그룹핑(섹터 → 종합 순). 커밋 메시지는 다중일 때 `(N개 파일)` 접미사.
- 기존 단일 파일 호출은 함수/CLI 양쪽에서 그대로 동작 (하위 호환).
- 테스트 36개 통과. 다중 파일/단일 파일 두 경로 모두 커버.

## Background
- 출처: JAE-83 (JAE-80 후속). 섹터별 MD 파일은 모두 정상 생성되나 메일/GitHub 에는 종합 1개만 전달되던 문제 해결.
- 권장 호출 순서: summary → ai → physical-ai → energy → game → other → valuechain-report

## Test plan
- [x] `pytest tests/test_email_weekly_report.py tests/test_push_weekly_report_to_github.py` — 36 passed.
- [x] CLI smoke: 단일 파일 호출이 기존 그대로 graceful degradation (SMTP 미설정 시 경고 후 종료).
- [ ] 운영 적용 후 다음 주간 리포트 발송에서 7개 섹터 파일이 한 메일에 묶여 도착하는지 검증 (루틴 description 갱신 + 다음 실행분 확인).