### PR TITLE
fix(data): JAE-92 pykrx 예외 시 DART fallback 가동

### DIFF
--- a/src/data/collector.py
+++ b/src/data/collector.py
@@ -395,6 +395,19 @@ def get_all_fundamentals(
 
     except Exception as e:
         logger.error(f"전 종목 기본 지표 조회 실패: {e}")
+        # pykrx 호출이 예외로 실패해도 DART fallback을 시도한다.
+        # KRX 포털 인증 실패(CD010 등)로 pykrx 응답이 깨진 경우에도 리밸런싱이 SKIP되지 않도록.
+        try:
+            logger.warning("pykrx 예외 발생 — DART fallback 시도: %s", d)
+            dart_df = _get_all_fundamentals_dart_fallback(d, market)
+            if not dart_df.empty:
+                logger.info(
+                    "DART fallback 성공: %d종목 (pykrx 예외 우회)", len(dart_df)
+                )
+                return dart_df
+            logger.error("DART fallback도 빈 결과를 반환했습니다 — 원본 예외 전파")
+        except Exception as dart_exc:
+            logger.error("DART fallback 자체가 실패: %s — 원본 예외 전파", dart_exc)
         raise
 
 

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -461,3 +461,50 @@ class TestGetAllFundamentals:
 
         assert isinstance(df, pd.DataFrame)
         assert df.empty, "market_cap 전부 0이면 빈 DataFrame이어야 한다"
+
+    @patch("src.data.collector._get_all_fundamentals_dart_fallback")
+    @patch("src.data.collector.pykrx_stock")
+    def test_dart_fallback_on_pykrx_exception(self, mock_pykrx, mock_dart_fallback):
+        """pykrx가 예외를 던지면 DART fallback이 호출되고 결과가 비어있지 않으면 그 결과를 반환한다.
+
+        Regression: JAE-92 — KRX 포털 인증 실패(CD010)로 pykrx가
+        ``KeyError("None of [Index([... 'PBR'...])] are in the [columns]")``
+        같은 예외를 던질 때 DART fallback이 우회 경로로 동작해야 한다.
+        """
+        mock_pykrx.get_market_fundamental.side_effect = KeyError(
+            "None of [Index(['BPS', 'PER', 'PBR', 'EPS', 'DIV', 'DPS'], "
+            "dtype='object')] are in the [columns]"
+        )
+        dart_df = pd.DataFrame(
+            {
+                "ticker": ["005930"],
+                "name": ["삼성전자"],
+                "market": ["KOSPI"],
+                "per": [10.0],
+                "pbr": [1.2],
+                "close": [70000],
+                "market_cap": [400_000_000_000_000],
+            }
+        )
+        mock_dart_fallback.return_value = dart_df
+
+        df = get_all_fundamentals("20240102", market="KOSPI")
+
+        assert not df.empty
+        assert "ticker" in df.columns
+        assert df.iloc[0]["ticker"] == "005930"
+        mock_dart_fallback.assert_called()
+
+    @patch("src.data.collector._get_all_fundamentals_dart_fallback")
+    @patch("src.data.collector.pykrx_stock")
+    def test_raises_when_pykrx_and_dart_both_fail(self, mock_pykrx, mock_dart_fallback):
+        """pykrx 예외 + DART fallback도 빈 결과면 retry 후 원본 예외를 raise한다."""
+        original_exc = RuntimeError("pykrx broken")
+        mock_pykrx.get_market_fundamental.side_effect = original_exc
+        mock_dart_fallback.return_value = pd.DataFrame()  # DART도 비어있음
+
+        with pytest.raises(RuntimeError, match="pykrx broken"):
+            get_all_fundamentals("20240102", market="KOSPI")
+
+        # retry decorator(max_retries=2)로 2회 호출 — 각 호출마다 DART fallback이 시도된다.
+        assert mock_dart_fallback.call_count >= 1


### PR DESCRIPTION
## 배경

[JAE-92](/JAE/issues/JAE-92) 월요일(2026-06-01) 09:05 리밸런싱이 시그널 생성 단계에서 실패.

이슈 본문의 추정 원인(월요일 당일 날짜 사용)은 **사실이 아님**. 실제 원인은 KRX 데이터 포털 인증 실패(CD010)로 pykrx 응답이 깨져 `KeyError: "None of [Index([...'PBR'...])] are in the [columns]"`를 던지는 상황.

## 변경

`src/data/collector.py::get_all_fundamentals()`의 `except` 절에서 raise 직전에 DART fallback을 시도. DART가 성공하면 그 결과 반환, DART도 빈 결과/예외면 원본 예외를 전파(기존 retry decorator 거동 유지).

기존에는 `if not results:` 분기에서만 DART fallback이 호출되어, **예외 경로**에서는 fallback이 작동하지 않았음.

## 효과

- KRX 포털 인증이 다시 깨지더라도 펀더멘탈은 DART로 수집되어 리밸런싱 가능
- 단, DART API_KEY가 설정되어 있고 DART에서 해당일 데이터가 회수 가능할 때 한정
- KOSPI 지수는 `_validate_signal_data()`에서 경고로만 분류되어 fatal 아님

## 테스트

- `tests/test_collector.py::TestGetAllFundamentals::test_dart_fallback_on_pykrx_exception` (신규)
- `tests/test_collector.py::TestGetAllFundamentals::test_raises_when_pykrx_and_dart_both_fail` (신규)
- 기존 8개 테스트 전부 통과

## 09:05 리밸런싱 안전성

`_validate_signal_data()`가 fatal 판정을 내리면 시그널 생성이 중단되므로 **주문은 발생하지 않음**. 즉, 현재 상태에서 자본 손실 위험은 없음.

## 후속 (별도 이슈로 분리 예정)

- KRX 자격증명 갱신 (CEO 승인 게이트, 운영 .env 수정 + systemctl restart)
- KOSPI 지수 FinanceDataReader fallback 추가
- KRX 로그인 실패 시 텔레그램 즉시 알림

## 거버넌스

- 실거래 로직 변경 없음 (데이터 수집 폴백 경로만 추가). 보드 승인 게이트 해당 없음.
- 운영 적용은 PR 머지 후 별도 systemctl restart 단계 — CEO 승인 필요.

Refs: [JAE-92](/JAE/issues/JAE-92), [JAE-91](/JAE/issues/JAE-91)

🤖 Generated with [Claude Code](https://claude.com/claude-code)