### PR TITLE
docs(research): JAE-95 우주테크(Space Tech) 섹터 F 신규 추가

### DIFF
--- a/docs/research/valuechain-layers-reference.md
+++ b/docs/research/valuechain-layers-reference.md
@@ -1,0 +1,511 @@
+# 섹터별 밸류체인 레이어 참조 (공통 문서)
+
+**문서 목적**: 주간 섹터 리포트 ([JAE-82](/JAE/issues/JAE-82) 루틴) 작성 시 각 섹터의 밸류체인 레이어 정의·구성 기업·관련 ETF를 일원화하여, 매 주간 리포트에서 동일한 레이어 구조로 모든 레이어를 빠짐없이 다루도록 한다.
+
+**관련 이슈**: [JAE-88](/JAE/issues/JAE-88) ← [JAE-80](/JAE/issues/JAE-80) ← [JAE-55](/JAE/issues/JAE-55)
+**적용 규칙**: 본 문서의 레이어 구조는 모든 섹터 리포트가 빠짐없이 다루어야 한다 (작성 규칙 10).
+
+---
+
+## A. AI 섹터 — 인공지능 소프트웨어/플랫폼
+
+### L1. 반도체·HBM·AI 가속기
+
+AI 학습·추론에 필요한 칩과 메모리. HBM·CoWoS·테스트 소켓 포함.
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | NVIDIA (NVDA), AMD, Broadcom, Marvell, Micron (MU), TSMC | 삼성전자(005930), SK하이닉스(000660), 한미반도체(042700), 리노공업(058470), 이오테크닉스(039030) |
+
+**관련 ETF**
+- 글로벌: iShares Semiconductor (SOXX), VanEck Semiconductor (SMH), Direxion Semis Bull 3x (SOXL)
+- 한국: ACE AI반도체포커스(469150), TIGER 미국필라델피아반도체나스닥(381180), KODEX 반도체(091160)
+
+### L2. 클라우드·하이퍼스케일러·인프라
+
+AI 학습 캐펙스가 향하는 인프라 계층.
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | Microsoft (MSFT, Azure), Amazon (AMZN, AWS), Alphabet (GOOGL, GCP), Oracle (ORCL), Meta (META) | 네이버(035420), 카카오(035720), KT(030200) |
+
+**관련 ETF**
+- 글로벌: Global X Cloud Computing (CLOU), First Trust Cloud (SKYY), WisdomTree Cloud (WCLD)
+- 한국: TIGER 미국나스닥100(133690) (간접 노출)
+
+### L3. 파운데이션 모델·LLM·기반 AI
+
+대규모 모델 학습·서비스 주체. 상장 노출은 제한적.
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | OpenAI (비상장), Anthropic (비상장), xAI (비상장), Cohere (비상장), Mistral (비상장), Alphabet (Gemini), Meta (Llama) | 직접 상장 미미 — 네이버(035420, HyperCLOVA X), LG AI연구원(LG, 003550 우회) |
+
+**관련 ETF**
+- 글로벌: Roundhill Generative AI & Tech (CHAT), Global X AIQ
+- 한국: 직접 노출 ETF 미미 — TIGER 글로벌AI&로보틱스INDXX(464310) 간접
+
+### L4. AI 응용·SaaS·생산성 (Copilot·Agentic AI)
+
+기업 SW에 AI 기능을 통합해 매출 기여 본격화.
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | Microsoft (Copilot), Salesforce (CRM, Agentforce), Adobe (ADBE, Firefly), Palantir (PLTR), ServiceNow (NOW), Databricks (비상장) | 더존비즈온(012510), 한글과컴퓨터(030520) |
+
+**관련 ETF**
+- 글로벌: Global X AIQ, WisdomTree AI & Innovation (WTAI)
+- 한국: HANARO Fn K-AI플러스(417810)
+
+### L5. 데이터·MLOps·벡터DB·검색
+
+AI 파이프라인 인프라.
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | Snowflake (SNOW), MongoDB (MDB), Confluent (CFLT), Elastic (ESTC), Pinecone (비상장), Weaviate (비상장) | 한컴인텔리전스(비상장) — 직접 상장 미미 |
+
+**관련 ETF**
+- 글로벌: Global X AIQ (포함), WisdomTree WTAI
+- 한국: 직접 노출 부재
+
+---
+
+## B. Physical AI & 로보틱스 섹터
+
+### L1. AI 컴퓨팅·로봇용 칩·엣지
+
+로봇 두뇌(엣지 AI 가속기).
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | NVIDIA (NVDA, Jetson·Thor), Qualcomm (QCOM, RB), Ambarella (AMBA), Tesla (TSLA, Dojo), Mobileye (MBLY) | 삼성전자 LSI (005930), 텔레칩스(054450), 넥스트칩(396270) |
+
+**관련 ETF**
+- 글로벌: Global X Robotics & AI (BOTZ), iShares Robotics (IRBO), ROBO Global Robotics (ROBO)
+- 한국: TIGER 글로벌AI&로보틱스INDXX(464310)
+
+### L2. 비전·라이다·센서·imager
+
+로봇이 세상을 인식하는 감각 기관.
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | Sony Semi (SONY, CMOS imager), Mobileye (MBLY), Luminar (LAZR), Hesai (HSAI), Velodyne | 한화비전(비상장 자회사·한화), 픽셀플러스(087600), 이미지넥스트, 카메라모듈 LG이노텍(011070) |
+
+**관련 ETF**
+- 글로벌: BOTZ, ROBO
+- 한국: KODEX 로봇액티브(445290), TIGER 글로벌AI&로보틱스(464310)
+
+### L3. 시뮬레이션·로보틱스 소프트웨어·운영체제
+
+Isaac·ROS·Omniverse 등 시뮬레이션·SDK.
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | NVIDIA (NVDA, Isaac·Omniverse), Open Robotics (ROS, 비상장), Anduril (비상장), Cognex (CGNX), Symbotic (SYM) | 직접 상장 미미 — 우리종합기계(비상장) |
+
+**관련 ETF**
+- 글로벌: BOTZ, ROBO
+- 한국: 직접 노출 부재
+
+### L4. 액추에이터·감속기·모터·구동계
+
+휴머노이드 관절·산업 로봇 구동의 핵심 부품 (직전 7일 catalyst 모니터링 1순위).
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | Harmonic Drive (TSE:6324), Nidec (TSE:6594), Fanuc (TSE:6954), ABB, Yaskawa | 에스피지(058610), 에스비비테크(388790), 로보티즈(108490), LG이노텍(011070, 액추에이터 일부) |
+
+**관련 ETF**
+- 글로벌: BOTZ, ROBO
+- 한국: KODEX 로봇액티브(445290), ACE K휴머노이드TOP2+ (코드 확인), RISE 현대차그룹 Fixed Physical AI (코드 확인)
+
+### L5. 배터리·전원·전력관리
+
+휴머노이드/모바일 로봇의 전원.
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | CATL (300750.SZ), BYD (002594.SZ), Tesla (TSLA, 4680) | LG에너지솔루션(373220), 삼성SDI(006400), SK온(비상장) |
+
+**관련 ETF**
+- 글로벌: Global X Lithium & Battery (LIT), Amplify Lithium (BATT)
+- 한국: TIGER 2차전지테마(305540), KODEX 2차전지산업(305720)
+
+### L6. 로봇 OEM·휴머노이드 본체
+
+휴머노이드 완성품·산업 로봇 본체.
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | Tesla (TSLA, Optimus), Figure AI (비상장), Agility Robotics (비상장), Boston Dynamics (현대차 자회사), 1X (비상장), Apptronik (비상장) | 레인보우로보틱스(277810), 두산로보틱스(454910), 유진로봇(056080) |
+
+**관련 ETF**
+- 글로벌: BOTZ, ROBO, Tema Robotics (RBOT)
+- 한국: KODEX 로봇액티브(445290), TIMEFOLIO 글로벌휴머노이드(상장 2026-05-19)
+
+### L7. 응용·인프라·자동차/물류/서비스 적용
+
+Physical AI가 실제로 배치되는 1차 시장.
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | BMW (BMW.DE), Mercedes-Benz (MBG.DE), Amazon (AMZN, 물류), Walmart (WMT, 물류), DHL | 현대차(005380), 현대모비스(012330), 한국타이어앤테크놀로지(161390), CJ대한통운(000120) |
+
+**관련 ETF**
+- 글로벌: First Trust Industrials/Producer Durables (FXR)
+- 한국: TIGER K휴머노이드(코드 확인), RISE 현대차그룹 Fixed Physical AI(코드 확인)
+
+---
+
+## C. 에너지 섹터 — 재생에너지·전력 인프라·SMR
+
+### L1. 발전 — SMR·원전·가스터빈·재생에너지
+
+전력 공급원. 직전 1년간 SMR + 가스터빈 사이클 강세.
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | NuScale (SMR), TerraPower (비상장), X-Energy (비상장), GE Vernova (GEV), Constellation Energy (CEG), Cameco (CCJ, 우라늄) | 두산에너빌리티(034020), 한국전력(015760), 한전기술(052690), 효성중공업(298040, 가스터빈 일부) |
+
+**관련 ETF**
+- 글로벌: VanEck Uranium+Nuclear (NLR), Range Nuclear Renaissance (NUKZ), Global X Uranium (URA)
+- 한국: KODEX 한국SMR(코드 확인), KODEX 미국SMR(코드 확인), TIGER 글로벌원자력(465980)
+
+### L2. 송배전·변압기·HVDC
+
+데이터센터 전력 수요 급증으로 송배전 사이클 동반.
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | GE Vernova (GEV), Siemens Energy (ENR.DE), Hitachi Energy, Eaton (ETN), Quanta Services (PWR) | 대한전선(001440), 일진전기(103590), 보성파워텍(006910), HD현대일렉트릭(267260), 효성중공업(298040), LS ELECTRIC(010120) |
+
+**관련 ETF**
+- 글로벌: First Trust Clean Edge Green Energy (QCLN), iShares Global Infrastructure (IGF)
+- 한국: TIGER KRX전력인프라(코드 확인), KODEX KRX전력기기(481310)
+
+### L3. ESS·배터리 저장
+
+전력 수급 평탄화·재생에너지 통합.
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | Tesla (TSLA, Megapack), Fluence (FLNC), Stem (STEM), CATL (300750.SZ) | LG에너지솔루션(373220), 삼성SDI(006400), 포스코퓨처엠(003670), 에코프로비엠(247540) |
+
+**관련 ETF**
+- 글로벌: Global X Lithium (LIT), Amplify Lithium (BATT)
+- 한국: TIGER 2차전지테마(305540), KODEX 2차전지산업(305720)
+
+### L4. 수요 — 데이터센터·전기차·전력 소비
+
+전력 수요 견인. AI 데이터센터 캐펙스가 주요 동인.
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | NextEra Energy (NEE), AEP (AEP), Dominion (D), Constellation (CEG), Equinix (EQIX, DC), Digital Realty (DLR, DC) | SKT(017670), KT(030200), LG U+(032640), SK텔레콤 데이터센터 사업 |
+
+**관련 ETF**
+- 글로벌: Utilities Select Sector SPDR (XLU), Global X Data Center & Digital Infra (VPN)
+- 한국: TIGER 미국S&P500전력(458730)
+
+### L5. 연료 — 수소·암모니아·LNG
+
+전환기 연료. 수소 모멘텀은 사이클성.
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | Plug Power (PLUG), Air Liquide (AI.PA), Linde (LIN), Cummins (CMI), Bloom Energy (BE) | 두산퓨얼셀(336260), 효성중공업 수소사업, 현대차그룹 수소 |
+
+**관련 ETF**
+- 글로벌: Global X Hydrogen (HYDR), Defiance Hydrogen (HDRO)
+- 한국: KBSTAR Fn수소경제테마(367770)
+
+---
+
+## D. 게임 섹터 — Interactive Entertainment
+
+### L1. 엔진·툴 — Unity·Unreal·GenAI 통합
+
+게임 제작 기반 도구.
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | Unity (U), Epic Games (비상장, Unreal), Roblox (RBLX, 자체 엔진), Cocos (비상장), Inworld AI (비상장, NPC) | 직접 노출 미미 — 펄어비스 자체 엔진(Black Space) |
+
+**관련 ETF**
+- 글로벌: VanEck Video Gaming & eSports (ESPO), Roundhill Video Games (NERD)
+- 한국: HANARO Fn K-게임(코드 확인), TIGER K게임(300610)
+
+### L2. 콘솔·하드웨어·휴대기기
+
+플랫폼 하드웨어.
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | Sony (SONY, PlayStation), Microsoft (MSFT, Xbox), Nintendo (NTDOY, Switch), Logitech (LOGI), Razer (1337.HK) | 직접 노출 부재 (앱코·BFC 등 주변기기) |
+
+**관련 ETF**
+- 글로벌: ESPO, NERD, iShares Video Games & eSports (HERO)
+- 한국: TIGER K게임(300610)
+
+### L3. 한국 스튜디오/퍼블리셔
+
+| 구분 | 한국 |
+|------|------|
+| 회사 | 크래프톤(259960), NCSoft(036570), 넷마블(251270), 펄어비스(263750), 카카오게임즈(293490), 위메이드(112040), 컴투스(078340), 시프트업(462870) |
+
+**관련 ETF**
+- 한국: TIGER K게임(300610), HANARO Fn K-게임(코드 확인)
+
+### L4. 글로벌 스튜디오/퍼블리셔
+
+| 구분 | 글로벌 |
+|------|--------|
+| 회사 | Microsoft Gaming (Activision 인수, MSFT), Electronic Arts (EA), Take-Two (TTWO), Ubisoft (UBI.PA), CD Projekt (CDR.WA), NetEase (NTES), Tencent (0700.HK), miHoYo (비상장) |
+
+**관련 ETF**
+- 글로벌: ESPO, NERD, HERO
+
+### L5. 퍼블리싱·광고·플랫폼
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | AppLovin (APP), Unity Ads, Sensor Tower (비상장), Steam Valve (비상장), Apple App Store (AAPL), Google Play (GOOGL) | KCB·페이코 인앱 결제 솔루션 일부 |
+
+**관련 ETF**
+- 글로벌: ESPO, NERD
+- 한국: 직접 노출 부재
+
+### L6. 블록체인·Web3·GenAI 콘텐츠
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | Immutable (비상장), Sky Mavis (Axie, 비상장), Mythical Games (비상장), Inworld AI (비상장) | 위메이드(112040, WEMIX), 카카오게임즈(293490, 보라), 넷마블(251270, MBX) |
+
+**관련 ETF**
+- 글로벌: VanEck Digital Transformation (DAPP)
+- 한국: KODEX K-메타버스액티브(401470)
+
+---
+
+## E. 그 외의 동향 — 자율주행·바이오·방산·금융·소비
+
+### E-A. 방산 (Defense)
+
+#### L1. 항공·우주·미사일
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | Lockheed Martin (LMT), Northrop Grumman (NOC), RTX (RTX), General Dynamics (GD), Boeing (BA) | 한국항공우주(047810), 한화에어로스페이스(012450), LIG넥스원(079550) |
+
+#### L2. 기갑·지상 무기
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | Rheinmetall (RHM.DE), BAE Systems (BA.L) | 현대로템(064350), 한화에어로스페이스(012450, K9·천무), 풍산(103140) |
+
+#### L3. 해양·잠수함
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | Huntington Ingalls (HII), General Dynamics (GD) | HD현대중공업(329180), 한화오션(042660), 삼성중공업(010140) |
+
+#### L4. 부품·MRO·통신
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | Heico (HEI), TransDigm (TDG) | LIG넥스원(079550), 한화시스템(272210), 빅텍(065450), 휴니드(005870) |
+
+**관련 ETF (E-A 통합)**
+- 글로벌: iShares U.S. Aerospace & Defense (ITA), Invesco Aerospace & Defense (PPA), SPDR S&P Aerospace & Defense (XAR)
+- 한국: KODEX K방산(449450), TIGER K방산(코드 확인)
+
+### E-B. 자율주행 (Autonomous Driving)
+
+#### L1. 컴퓨팅·플랫폼
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | NVIDIA (NVDA, Thor), Mobileye (MBLY), Qualcomm (QCOM, Ride), Tesla (TSLA, FSD) | 삼성전자 LSI(005930), 텔레칩스(054450), 만도(204320, 도메인 컨트롤러) |
+
+#### L2. 센서 (LIDAR·카메라·레이더)
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | Luminar (LAZR), Hesai (HSAI), Innoviz (INVZ), Aeva (AEVA), Continental (CON.DE) | LG이노텍(011070, 카메라), 삼성전기(009150), 만도모빌리티솔루션즈 |
+
+#### L3. OEM·완성차
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | Tesla (TSLA), Waymo (Alphabet), BYD (002594.SZ), Mercedes-Benz | 현대차(005380), 기아(000270) |
+
+#### L4. 부품·소프트웨어·맵
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | Aptiv (APTV), Magna (MGA), HERE (비상장) | 현대모비스(012330), 만도(204320), 현대오토에버(307950), 카카오모빌리티(비상장) |
+
+**관련 ETF (E-B)**
+- 글로벌: Global X Autonomous & Electric Vehicles (DRIV), KraneShares Electric Vehicles (KARS)
+- 한국: TIGER 차이나전기차SOLACTIVE(371460) (간접), TIGER K-자율주행&로보틱스(코드 확인)
+
+### E-C. 바이오 CDMO·신약 (Bio CDMO/Pharma)
+
+#### L1. CDMO·위탁생산
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | Lonza (LONN.SW), Catalent (CTLT), WuXi Biologics (2269.HK), Samsung Biologics (007310 - KR) | 삼성바이오로직스(207940), SK바이오사이언스(302440) |
+
+#### L2. 신약 (Big Pharma + Biotech)
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | Pfizer (PFE), Eli Lilly (LLY), Novo Nordisk (NVO), Merck (MRK), Roche (ROG.SW), Moderna (MRNA) | 셀트리온(068270), 한미약품(128940), 유한양행(000100), 알테오젠(196170) |
+
+#### L3. 진단·의료기기
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | Roche Diagnostics, Abbott (ABT), Thermo Fisher (TMO) | 씨젠(096530), 휴마시스(205470), 메디톡스(086900) |
+
+**관련 ETF (E-C)**
+- 글로벌: iShares Biotech (IBB), SPDR Biotech (XBI), VanEck Biotech (BBH)
+- 한국: TIGER 바이오TOP10(364980), KODEX 바이오(244580)
+
+### E-D. 금융·핀테크 (Finance/Fintech)
+
+#### L1. 시중은행·금융지주
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | JPMorgan (JPM), Bank of America (BAC), Wells Fargo (WFC), HSBC (HSBC) | KB금융(105560), 신한지주(055550), 하나금융지주(086790), 우리금융지주(316140) |
+
+#### L2. 증권·자산운용
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | Morgan Stanley (MS), Goldman Sachs (GS), BlackRock (BLK), Charles Schwab (SCHW) | 미래에셋증권(006800), NH투자증권(005940), 한국투자증권(비상장), 키움증권(039490) |
+
+#### L3. 핀테크·인터넷은행·결제
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | Block (SQ), PayPal (PYPL), Stripe (비상장), Coinbase (COIN), Robinhood (HOOD) | 카카오뱅크(323410), 카카오페이(377300), 토스(비상장), 케이뱅크(279060) |
+
+**관련 ETF (E-D)**
+- 글로벌: Financial Select Sector SPDR (XLF), Global X FinTech (FINX)
+- 한국: KODEX 은행(091170), TIGER 은행(091220)
+
+### E-E. 소비·콘텐츠 (Consumer/Content)
+
+#### L1. K-콘텐츠·엔터테인먼트
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | Netflix (NFLX), Disney (DIS), Warner Bros Discovery (WBD), Spotify (SPOT) | CJ ENM(035760), 하이브(352820), SM엔터(041510), JYP Ent(035900), YG엔터(122870) |
+
+#### L2. 면세·유통
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | LVMH (MC.PA), Estee Lauder (EL), Walmart (WMT), Costco (COST) | 호텔신라(008770), 신세계(004170), 롯데쇼핑(023530), 이마트(139480) |
+
+#### L3. 식음료·소비재
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | Nestle (NESN.SW), Coca-Cola (KO), PepsiCo (PEP), Mondelez (MDLZ) | CJ제일제당(097950), 농심(004370), 오리온(271560), KT&G(033780) |
+
+**관련 ETF (E-E)**
+- 글로벌: Consumer Discretionary Select Sector SPDR (XLY), Consumer Staples Select Sector SPDR (XLP)
+- 한국: TIGER K-뉴딜MZ소비(312610), KODEX K-콘텐츠(코드 확인)
+
+---
+
+## F. 우주테크 섹터 — Space Tech (발사체·위성·지상국·응용)
+
+신규 추가 ([JAE-94](/JAE/issues/JAE-94) → [JAE-95](/JAE/issues/JAE-95), 2026-06-01). 글로벌 New Space 상업화(SpaceX 비상장 / Starlink / Rocket Lab Neutron / AST SpaceMobile D2C) + 한국 누리호 5호기(2026 Q3 예정)·발사체 민간화·위성통신 D2C 사이클을 추적한다. 5 레이어 구조.
+
+### L1. 발사체·로켓엔진
+
+발사체(런처) + 로켓엔진·추진제·구조체. 한국은 누리호 체계종합기업 한화에어로 + 민간 발사체 이노스페이스 2축.
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | SpaceX (비상장), Rocket Lab (RKLB), Blue Origin (비상장, Amazon), Firefly Aerospace (FLY), United Launch Alliance (비상장), Astra (ASTR) | 한화에어로스페이스(012450, 누리호 체계종합·엔진), 이노스페이스(462350, 한빛 발사체), 한국항공우주(047810, KSLV 일부) |
+
+**관련 ETF**
+- 글로벌: Procure Space (UFO), ARK Space Exploration (ARKX), SPDR S&P Kensho Final Frontiers (ROKT)
+- 한국: TIGER K방산&우주(463250) (방산 비중 일부 중첩), KODEX 미국우주항공(코드 확인, 2026-03-17 상장)
+
+### L2. 위성 제조·위성 플랫폼
+
+위성 본체·플랫폼·페이로드·서브시스템. 한국은 쎄트렉아이(한화 계열, 비상장 자회사화)·LIG넥스원 위성 사업 + 한화시스템 SAR/페이로드 핵심.
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | Maxar (비상장, Advent 인수), Planet Labs (PL), Lockheed Martin (LMT, 위성 부문), Airbus (AIR.PA), Thales Alenia (HO.PA), Sidus Space (SIDU), Redwire (RDW) | LIG넥스원(079550, 군 위성·천리안 통신탑재체), 한화시스템(272210, 위성 페이로드·SAR), 쎄트렉아이(한화 자회사·비상장 전환), 컨텍(451760, 위성 본체 일부) |
+
+**관련 ETF**
+- 글로벌: UFO, ARKX, ROKT
+- 한국: TIGER K방산&우주(463250)
+
+### L3. 지상국·위성통신·데이터 (GSaaS)
+
+지상국 네트워크·관제·다운링크·위성통신 안테나·해상/항공 통신. 한국은 컨텍(글로벌 GSaaS) + 인텔리안테크(LEO 안테나) 핵심.
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | Iridium Communications (IRDM), Globalstar (GSAT), AST SpaceMobile (ASTS, D2C), EchoStar (SATS, Starlink 지분 보유), Viasat (VSAT), KSAT (비상장, 노르웨이) | 컨텍(451760, GSaaS·지상국 네트워크), 인텔리안테크(189300, LEO·해상 안테나), KT SAT(KT 030200 자회사·비상장) |
+
+**관련 ETF**
+- 글로벌: UFO, ARKX
+- 한국: TIGER K방산&우주(463250) (간접)
+
+### L4. 위성 서비스·응용 (관측·항법·SAR·D2C)
+
+위성을 활용한 응용 서비스 — 지구관측(EO), SAR, PNT(항법), IoT·D2C 통신. 응용 단계 매출이 가장 빠르게 확장.
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | Planet Labs (PL, EO), BlackSky (BKSY, 첩보 EO), Spire Global (SPIR, RF/AIS), AST SpaceMobile (ASTS, D2C), Iridium (IRDM, IoT), Trimble (TRMB, PNT) | 한화시스템(272210, SAR·국방 응용), LIG넥스원(079550, 군 응용), SK텔레콤(017670, D2C 위성통신 협업), KT(030200, D2C·해사 위성) |
+
+**관련 ETF**
+- 글로벌: UFO, ARKX, ROKT
+- 한국: TIGER K방산&우주(463250)
+
+### L5. 우주 탐사·심우주·우주 관광
+
+심우주 미션·달·화성·우주 관광. 매출 기여는 장기. 7일 단위 catalyst는 정부 발사·NASA·우주청 발표 의존.
+
+| 구분 | 글로벌 | 한국 |
+|------|--------|------|
+| 회사 | SpaceX (비상장, Starship), Blue Origin (비상장, New Glenn), Intuitive Machines (LUNR, 달 착륙선), Astrobotic (비상장), Virgin Galactic (SPCE, 준궤도 관광) | 한국항공우주(047810, KARI 협업), 한화에어로스페이스(012450, 차세대발사체) — 직접 노출 제한적 |
+
+**관련 ETF**
+- 글로벌: UFO, ARKX
+- 한국: 직접 노출 부재 — TIGER K방산&우주(463250) 간접
+
+---
+
+## 사용 규칙
+
+1. 각 섹터 주간 리포트는 본 문서의 **모든 레이어 챕터**를 빠짐없이 포함한다 (작성 규칙 10).
+2. 레이어별 챕터에는 다음 4가지 필수 요소를 모두 포함한다:
+   - 챕터 상단 요약 (1~2줄)
+   - 해당 레이어 주요 회사 (글로벌/한국 분리) + 각사 직전 7일 catalyst·주가·뉴스
+   - 금주 주요 이슈·이벤트 (긍정/부정 신호 명시 + 차주 영향 예상)
+   - 관련 ETF (글로벌/한국 분리) + 이번주 이슈 포인트
+   - 차주 투자 관점 점수 (1~10점)
+3. 해당 레이어에 직전 7일 내 catalyst·뉴스가 부재한 경우, 챕터에서 **명시적으로 "7일 내 catalyst 미확인"** 표시하고 점수 산정의 신뢰도를 낮춤 ([JAE-88](/JAE/issues/JAE-88) 규칙 9 연동).
+4. 본 문서의 회사·ETF 목록은 동적이며, 신규 상장·인수합병 등으로 갱신이 필요하면 주간 리포트 보고에서 별도 PR로 본 문서를 업데이트한다.
+
+---
+
+## 변경 이력
+
+- 2026-05-30 — 초안 작성 ([JAE-88](/JAE/issues/JAE-88) 보드 추가 피드백 반영). 5개 섹터 (+ E의 5개 서브섹터) 레이어 정의 + 회사 + ETF 매핑.
+- 2026-06-01 — F. 우주테크 섹터 신규 추가 ([JAE-94](/JAE/issues/JAE-94) CEO 위임 → [JAE-95](/JAE/issues/JAE-95) QuantResearcher 실행). L1 발사체·로켓엔진 / L2 위성 제조·플랫폼 / L3 지상국·위성통신·데이터 / L4 위성 서비스·응용 / L5 우주 탐사·심우주·관광. 다음 주간 리포트(2026-06-06 이후 발행)부터 [F] 섹터 파일 `YYYY-MM-DD-weekly-sector-space.md`로 포함. 인덱스 테이블·섹터 요약에 [F] 행 추가.

--- a/src/data/collector.py
+++ b/src/data/collector.py
@@ -395,6 +395,19 @@ def get_all_fundamentals(
 
     except Exception as e:
         logger.error(f"전 종목 기본 지표 조회 실패: {e}")
+        # pykrx 호출이 예외로 실패해도 DART fallback을 시도한다.
+        # KRX 포털 인증 실패(CD010 등)로 pykrx 응답이 깨진 경우에도 리밸런싱이 SKIP되지 않도록.
+        try:
+            logger.warning("pykrx 예외 발생 — DART fallback 시도: %s", d)
+            dart_df = _get_all_fundamentals_dart_fallback(d, market)
+            if not dart_df.empty:
+                logger.info(
+                    "DART fallback 성공: %d종목 (pykrx 예외 우회)", len(dart_df)
+                )
+                return dart_df
+            logger.error("DART fallback도 빈 결과를 반환했습니다 — 원본 예외 전파")
+        except Exception as dart_exc:
+            logger.error("DART fallback 자체가 실패: %s — 원본 예외 전파", dart_exc)
         raise
 
 

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -461,3 +461,50 @@ class TestGetAllFundamentals:
 
         assert isinstance(df, pd.DataFrame)
         assert df.empty, "market_cap 전부 0이면 빈 DataFrame이어야 한다"
+
+    @patch("src.data.collector._get_all_fundamentals_dart_fallback")
+    @patch("src.data.collector.pykrx_stock")
+    def test_dart_fallback_on_pykrx_exception(self, mock_pykrx, mock_dart_fallback):
+        """pykrx가 예외를 던지면 DART fallback이 호출되고 결과가 비어있지 않으면 그 결과를 반환한다.
+
+        Regression: JAE-92 — KRX 포털 인증 실패(CD010)로 pykrx가
+        ``KeyError("None of [Index([... 'PBR'...])] are in the [columns]")``
+        같은 예외를 던질 때 DART fallback이 우회 경로로 동작해야 한다.
+        """
+        mock_pykrx.get_market_fundamental.side_effect = KeyError(
+            "None of [Index(['BPS', 'PER', 'PBR', 'EPS', 'DIV', 'DPS'], "
+            "dtype='object')] are in the [columns]"
+        )
+        dart_df = pd.DataFrame(
+            {
+                "ticker": ["005930"],
+                "name": ["삼성전자"],
+                "market": ["KOSPI"],
+                "per": [10.0],
+                "pbr": [1.2],
+                "close": [70000],
+                "market_cap": [400_000_000_000_000],
+            }
+        )
+        mock_dart_fallback.return_value = dart_df
+
+        df = get_all_fundamentals("20240102", market="KOSPI")
+
+        assert not df.empty
+        assert "ticker" in df.columns
+        assert df.iloc[0]["ticker"] == "005930"
+        mock_dart_fallback.assert_called()
+
+    @patch("src.data.collector._get_all_fundamentals_dart_fallback")
+    @patch("src.data.collector.pykrx_stock")
+    def test_raises_when_pykrx_and_dart_both_fail(self, mock_pykrx, mock_dart_fallback):
+        """pykrx 예외 + DART fallback도 빈 결과면 retry 후 원본 예외를 raise한다."""
+        original_exc = RuntimeError("pykrx broken")
+        mock_pykrx.get_market_fundamental.side_effect = original_exc
+        mock_dart_fallback.return_value = pd.DataFrame()  # DART도 비어있음
+
+        with pytest.raises(RuntimeError, match="pykrx broken"):
+            get_all_fundamentals("20240102", market="KOSPI")
+
+        # retry decorator(max_retries=2)로 2회 호출 — 각 호출마다 DART fallback이 시도된다.
+        assert mock_dart_fallback.call_count >= 1


### PR DESCRIPTION
## Summary
- `valuechain-layers-reference.md`에 **F. 우주테크 섹터** 신규 추가 (L1~L5 5 레이어).
- 다음 주간 리포트부터 `YYYY-MM-DD-weekly-sector-space.md` 파일을 포함하고, 섹터 요약·인덱스 테이블에 [F] 행을 추가한다 (별도 후속 작업).
- 출처: [JAE-94](https://example.com) CEO 위임 → [JAE-95](https://example.com) QuantResearcher 실행.

## 레이어 매핑

| 레이어 | 정의 | 한국 핵심 | 글로벌 핵심 |
|--------|------|----------|------------|
| L1 | 발사체·로켓엔진 | 한화에어로(012450), 이노스페이스(462350), 한국항공우주(047810) | SpaceX(비상장), RKLB, BO, FLY |
| L2 | 위성 제조·플랫폼 | LIG넥스원(079550), 한화시스템(272210), 쎄트렉아이, 컨텍(451760) | Maxar, PL, LMT, AIR.PA, RDW |
| L3 | 지상국·위성통신 | 컨텍(451760), 인텔리안테크(189300), KT SAT | IRDM, GSAT, ASTS, SATS |
| L4 | 위성 서비스·응용 | 한화시스템, LIG넥스원, SKT, KT | PL, BKSY, SPIR, ASTS, IRDM |
| L5 | 우주 탐사·심우주·관광 | 한국항공우주, 한화에어로 | SpaceX(비상장), BO(비상장), LUNR, SPCE |

## ETF 매핑
- 한국: TIGER K방산&우주(463250), KODEX 미국우주항공(2026-03-17 상장)
- 글로벌: Procure Space (UFO), ARK Space Exploration (ARKX), SPDR Final Frontiers (ROKT)

## Test plan
- [x] `valuechain-layers-reference.md` 마크다운 렌더링 확인 (테이블 깨짐 없음)
- [x] L1~L5 레이어별 글로벌·한국·ETF 3 요소 모두 채움
- [x] [JAE-94](https://example.com), [JAE-95](https://example.com) 링크 및 변경 이력 갱신
- [ ] 후속: 다음 주간 리포트 작성 시 [F] 섹터 파일 포함 (별도 heartbeat)