### PR TITLE
fix(execution): JAE-100 ETF 자동 보충 시 미태깅 장기 포지션 전량 매도 차단

### DIFF
--- a/scripts/jae100_restore_allocation.py
+++ b/scripts/jae100_restore_allocation.py
@@ -1,0 +1,148 @@
+"""JAE-100 복구: portfolio_allocation.json 재태깅.
+
+ETF 유니버스에 포함된 보유 종목은 etf_rotation, 그 외는 long_term으로
+backfill한다. backfill_untagged_positions()와 동일 로직을 사용해
+이미 태깅된 포지션은 건드리지 않는다.
+
+사용법:
+    # dry-run (변경 미적용)
+    python scripts/jae100_restore_allocation.py --dry-run
+
+    # 실제 적용
+    python scripts/jae100_restore_allocation.py --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="JAE-100 allocation.json 복구")
+    parser.add_argument(
+        "--apply", action="store_true",
+        help="실제 파일에 적용. 미지정 시 dry-run.",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="명시적 dry-run (기본 동작).",
+    )
+    parser.add_argument(
+        "--allocation-path",
+        default="/mnt/data/quant/data/portfolio_allocation.json",
+        help="복구 대상 allocation.json 경로",
+    )
+    args = parser.parse_args()
+
+    if args.apply and args.dry_run:
+        print("ERROR: --apply 와 --dry-run 동시 지정 불가")
+        return 2
+
+    apply_mode = args.apply
+
+    sys.path.insert(0, "/mnt/data/quant-dev")
+    from src.execution.kis_client import KISClient
+    from src.execution.portfolio_allocator import PortfolioAllocator
+    from src.scheduler.main import TradingBot
+
+    alloc_path = Path(args.allocation_path)
+    if not alloc_path.exists():
+        print(f"ERROR: allocation 파일 없음: {alloc_path}")
+        return 1
+
+    print(f"[1/5] 현재 allocation.json 백업 준비")
+    backup_path = alloc_path.with_suffix(
+        f".json.bak.{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+    )
+
+    print(f"[2/5] 현재 allocation 내용:")
+    current = json.loads(alloc_path.read_text(encoding="utf-8"))
+    print(json.dumps(current, ensure_ascii=False, indent=2))
+
+    print(f"[3/5] KIS 잔고 조회 및 ETF 유니버스 수집")
+    kis = KISClient()
+    bot = TradingBot(kis_client=kis)
+    etf_universe = bot._get_etf_universe_tickers()
+    print(f"  ETF 유니버스 종목 수: {len(etf_universe)}")
+    print(f"  ETF 유니버스: {sorted(etf_universe)}")
+
+    balance = kis.get_balance()
+    holdings = balance.get("holdings", [])
+    print(f"  KIS 보유 종목 수: {len(holdings)}")
+    for h in holdings:
+        print(
+            f"    {h.get('ticker')} qty={h.get('qty')} "
+            f"eval={h.get('eval_amount')}"
+        )
+
+    print(f"[4/5] 복구 시뮬레이션 (long_term_pct={bot.allocator._long_term_pct})")
+    # 복구 후 예상 상태 계산
+    existing_tags = current.get("positions", {})
+    plan: dict[str, dict] = dict(existing_tags)
+    new_tags = 0
+    for h in holdings:
+        ticker = h.get("ticker", "")
+        qty = h.get("qty", 0)
+        if not ticker or qty <= 0:
+            continue
+        if ticker in plan:
+            continue  # 이미 태깅
+        if ticker in etf_universe:
+            plan[ticker] = {
+                "pool": "etf_rotation",
+                "entry_date": datetime.now().strftime("%Y-%m-%d"),
+                "backfilled": True,
+                "jae100_restore": True,
+            }
+        else:
+            plan[ticker] = {
+                "pool": "long_term",
+                "entry_date": datetime.now().strftime("%Y-%m-%d"),
+                "backfilled": True,
+                "jae100_restore": True,
+            }
+        new_tags += 1
+        print(f"    + 신규 태깅: {ticker} → {plan[ticker]['pool']}")
+
+    print(f"  신규 태깅 종목 수: {new_tags}")
+
+    print(f"[5/5] 적용 단계")
+    if not apply_mode:
+        print("  --apply 미지정 → dry-run 종료. 적용하려면 --apply 사용.")
+        print(f"  예상 결과 미리보기:")
+        print(json.dumps(plan, ensure_ascii=False, indent=2))
+        return 0
+
+    if new_tags == 0:
+        print("  변경 없음 — 파일 그대로 유지.")
+        return 0
+
+    print(f"  백업: {backup_path}")
+    shutil.copy2(alloc_path, backup_path)
+
+    new_doc = dict(current)
+    new_doc["positions"] = plan
+    new_doc["updated_at"] = datetime.now().isoformat(timespec="seconds")
+    new_doc["jae100_restore_note"] = (
+        f"JAE-100 복구: {new_tags}개 미태깅 포지션을 재태깅. "
+        f"백업={backup_path.name}"
+    )
+    alloc_path.write_text(
+        json.dumps(new_doc, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    print(f"  적용 완료: {alloc_path}")
+    print(
+        "  주의: 운영 중인 quant-bot 프로세스는 메모리 상태를 캐시한다. "
+        "변경 사항이 즉시 반영되려면 systemd 재시작이 필요하다 (CEO 승인 필요)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/execution/portfolio_allocator.py
+++ b/src/execution/portfolio_allocator.py
@@ -473,20 +473,41 @@ class PortfolioAllocator:
             )
             tagged_count += 1
 
-        # 시그널에 없는 기존 태그 정리
-        with self._lock:
-            positions = self._data.get("positions", {})
-            stale = [
-                t for t in positions
-                if t not in ticker_best_pool
-                and positions[t].get("pool") != "short_term"
-            ]
-            for t in stale:
-                del positions[t]
-            if stale:
-                self._data["positions"] = positions
-                self._save()
-                logger.info("자동 태그 정리: %d개 종목 태그 제거", len(stale))
+        # JAE-100: stale 태그 정리는 "실제 매도되어 보유하지 않는" 종목에만 적용한다.
+        # 기존 로직은 새 시그널에 없는 모든 태그를 제거해, 백필된 장기 종목을 매 리밸런싱마다
+        # 무력화해 ETF 단독 리밸런싱 시 미태깅 포지션 전량 매도 사고를 유발했다.
+        try:
+            balance = self._kis_client.get_balance()
+            held_tickers = {
+                h.get("ticker")
+                for h in balance.get("holdings", [])
+                if h.get("ticker") and h.get("qty", 0) > 0
+            }
+        except Exception as e:
+            logger.warning(
+                "자동 태깅 stale 정리 중 잔고 조회 실패 — 정리 스킵: %s", e
+            )
+            held_tickers = None
+
+        if held_tickers is not None:
+            with self._lock:
+                positions = self._data.get("positions", {})
+                # 보호 대상: short_term 풀, 새 시그널에 포함된 종목(방금 태깅됨),
+                # KIS 잔고에 있는 종목(아직 보유 중)
+                stale = [
+                    t for t in positions
+                    if t not in held_tickers
+                    and t not in ticker_best_pool
+                    and positions[t].get("pool") != "short_term"
+                ]
+                for t in stale:
+                    del positions[t]
+                if stale:
+                    self._data["positions"] = positions
+                    self._save()
+                    logger.info(
+                        "자동 태그 정리: 미보유 %d개 종목 태그 제거", len(stale)
+                    )
 
         logger.info("자동 태깅 완료: %d개 종목", tagged_count)
 

--- a/src/execution/position_manager.py
+++ b/src/execution/position_manager.py
@@ -231,36 +231,34 @@ class PositionManager:
             logger.error("포트폴리오 가치가 0원입니다. 리밸런싱을 중단합니다.")
             return [], []
 
-        # 1-1. allocator가 있으면 다른 풀의 포지션을 현재 포지션에서 제외
-        # 통합 모드에서는 전체 포트폴리오를 대상으로 하므로 제외하지 않음
+        # 1-1. allocator가 있으면 풀-스코프로 현재 포지션을 필터링한다.
+        # 통합 모드에서는 전체 포트폴리오를 대상으로 하므로 필터링하지 않는다.
+        # JAE-100: 기존 로직(다른 풀 제외)은 미태깅 포지션을 무방어 상태로 두어
+        # ETF 단독 리밸런싱 시 장기 종목을 전량 매도하는 사고가 발생했다.
+        # 변경: 대상 풀에 명시적으로 태깅된 포지션만 diff 대상에 포함한다.
         if allocator is not None and not integrated:
-            all_pools = {"long_term", "short_term", "etf_rotation"}
             target_pool = pool or "long_term"
-            exclude_pools = all_pools - {target_pool}
+            target_tickers = {
+                p["ticker"]
+                for p in allocator.get_positions_by_pool(target_pool)
+            }
+            # target_weights에 포함된 신규 진입 종목은 보호(매수 가능하도록 허용)
+            allow_tickers = target_tickers | set(target_weights.keys())
 
-            exclude_tickers: set[str] = set()
-            for excl_pool in exclude_pools:
-                tickers = {
-                    p["ticker"]
-                    for p in allocator.get_positions_by_pool(excl_pool)
-                }
-                exclude_tickers |= tickers
-
-            if exclude_tickers:
-                excluded = {
-                    t for t in current_positions if t in exclude_tickers
-                }
-                current_positions = {
-                    t: q for t, q in current_positions.items()
-                    if t not in exclude_tickers
-                }
-                if excluded:
-                    logger.info(
-                        "allocator: %s 외 풀 포지션 %d개 제외: %s",
-                        target_pool,
-                        len(excluded),
-                        ", ".join(sorted(excluded)),
-                    )
+            excluded = {
+                t for t in current_positions if t not in allow_tickers
+            }
+            current_positions = {
+                t: q for t, q in current_positions.items()
+                if t in allow_tickers
+            }
+            if excluded:
+                logger.info(
+                    "allocator: %s 풀 외 포지션 %d개 보호(매도 대상 제외): %s",
+                    target_pool,
+                    len(excluded),
+                    ", ".join(sorted(excluded)),
+                )
 
         # 2. 목표 수량 계산
         target_quantities = self.calculate_target_quantities(

--- a/src/scheduler/main.py
+++ b/src/scheduler/main.py
@@ -1648,6 +1648,25 @@ class TradingBot:
                 )
                 return
 
+            # JAE-100: ETF 풀 단독 리밸런싱 전에 미태깅 포지션을 보강한다.
+            # 미태깅 종목이 ETF 풀로 잘못 분류되어 전량 매도되는 사고를 방지한다.
+            if self.allocator is not None:
+                try:
+                    tagged = self.allocator.backfill_untagged_positions(
+                        etf_tickers=self._get_etf_universe_tickers(),
+                        default_pool="long_term",
+                    )
+                    if isinstance(tagged, int) and tagged > 0:
+                        logger.warning(
+                            "ETF 자동 보충: 미태깅 포지션 %d개를 long_term으로 보강",
+                            tagged,
+                        )
+                except Exception as e:
+                    logger.warning(
+                        "ETF 자동 보충: backfill 실패 — 보호 로직(target pool 한정)에 의존: %s",
+                        e,
+                    )
+
             cash_ratio, etf_cash, etf_budget = self._get_etf_cash_ratio()
             self._send_notification(
                 f"[ETF 자동 보충 매수 실행] {today.strftime('%Y-%m-%d')}\n"

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -1024,21 +1024,22 @@ class TestPositionManagerWithAllocator:
         return pm
 
     def test_allocator_excludes_short_term_positions(self):
-        """allocator가 있으면 단기 포지션이 리밸런싱에서 제외된다."""
-        # 현재 보유: A=10주, B=5주 (B는 단기)
-        # 목표: A=100%
-        # allocator 없이: B 5주 매도 발생
-        # allocator 있으면: B는 제외, A만 조정
+        """allocator가 있으면 단기 포지션이 장기 리밸런싱에서 제외된다."""
+        # 현재 보유: A=10주(장기), B=5주(단기)
+        # 목표(장기 풀): A=100%
+        # allocator 있으면: B는 다른 풀이므로 매도 대상에서 제외
         current = {"005930": 10, "000660": 5}
         prices = {"005930": 100_000, "000660": 200_000}
         portfolio_value = 2_000_000
 
         pm = self._make_position_manager(current, portfolio_value, prices)
 
-        # allocator mock: 000660이 단기
+        # allocator mock: 005930이 장기, 000660이 단기
         mock_allocator = MagicMock()
 
         def _get_by_pool(pool):
+            if pool == "long_term":
+                return [{"ticker": "005930", "pool": "long_term"}]
             if pool == "short_term":
                 return [{"ticker": "000660", "pool": "short_term"}]
             return []
@@ -1050,12 +1051,11 @@ class TestPositionManagerWithAllocator:
             allocator=mock_allocator,
         )
 
-        # short_term과 etf_rotation 2개 풀이 제외 대상으로 조회됨
+        # JAE-100: 새 의미론은 target pool(long_term)에 태깅된 종목 + target_weights만 허용
         call_args = [
             c[0][0] for c in mock_allocator.get_positions_by_pool.call_args_list
         ]
-        assert "short_term" in call_args
-        assert "etf_rotation" in call_args
+        assert "long_term" in call_args
 
         # 000660에 대한 매도 주문이 없어야 함
         sell_tickers = {o["ticker"] for o in sell_orders}
@@ -1082,7 +1082,7 @@ class TestPositionManagerWithAllocator:
         )
 
     def test_allocator_no_short_term_positions(self):
-        """allocator가 있지만 단기 포지션이 없으면 기존과 동일하게 동작한다."""
+        """allocator가 있지만 단기 포지션이 없으면 정상적으로 리밸런싱한다."""
         current = {"005930": 10}
         prices = {"005930": 100_000}
         portfolio_value = 1_000_000
@@ -1090,21 +1090,33 @@ class TestPositionManagerWithAllocator:
         pm = self._make_position_manager(current, portfolio_value, prices)
 
         mock_allocator = MagicMock()
-        mock_allocator.get_positions_by_pool.return_value = []
+        # 005930만 long_term으로 태깅된 상태
+        def _get_by_pool(pool):
+            if pool == "long_term":
+                return [{"ticker": "005930", "pool": "long_term"}]
+            return []
+
+        mock_allocator.get_positions_by_pool.side_effect = _get_by_pool
 
         sell_orders, buy_orders = pm.calculate_rebalance_orders(
             {"005930": 1.0},
             allocator=mock_allocator,
         )
 
-        # 단기/ETF 포지션이 없으므로 정상적으로 리밸런싱
+        # target_pool인 long_term이 조회됨
         called_pools = {c.args[0] for c in mock_allocator.get_positions_by_pool.call_args_list}
-        assert "short_term" in called_pools
-        assert "etf_rotation" in called_pools
+        assert "long_term" in called_pools
+
+        # 005930은 target_pool에 포함됨 → 전량 매도 대상이 아니어야 함
+        # (buy_cost 보정으로 인한 미세 조정 매도는 허용)
+        sell_for_005930 = [o for o in sell_orders if o["ticker"] == "005930"]
+        if sell_for_005930:
+            # 전량 매도가 아니라 미세 조정인지 확인
+            assert sell_for_005930[0]["qty"] < 10
 
     def test_allocator_excludes_multiple_short_term(self):
         """allocator가 여러 단기 종목을 제외한다."""
-        # 현재 보유: A, B, C, D (C, D가 단기)
+        # 현재 보유: A, B(장기), C, D(단기)
         current = {"A": 10, "B": 20, "C": 5, "D": 3}
         prices = {"A": 10_000, "B": 10_000, "C": 10_000, "D": 10_000}
         portfolio_value = 1_000_000
@@ -1112,12 +1124,23 @@ class TestPositionManagerWithAllocator:
         pm = self._make_position_manager(current, portfolio_value, prices)
 
         mock_allocator = MagicMock()
-        mock_allocator.get_positions_by_pool.return_value = [
-            {"ticker": "C", "pool": "short_term"},
-            {"ticker": "D", "pool": "short_term"},
-        ]
 
-        # 목표: A=50%, B=50% -> C, D 매도 X
+        def _get_by_pool(pool):
+            if pool == "long_term":
+                return [
+                    {"ticker": "A", "pool": "long_term"},
+                    {"ticker": "B", "pool": "long_term"},
+                ]
+            if pool == "short_term":
+                return [
+                    {"ticker": "C", "pool": "short_term"},
+                    {"ticker": "D", "pool": "short_term"},
+                ]
+            return []
+
+        mock_allocator.get_positions_by_pool.side_effect = _get_by_pool
+
+        # 목표(장기): A=50%, B=50% -> C, D 매도 X
         sell_orders, buy_orders = pm.calculate_rebalance_orders(
             {"A": 0.50, "B": 0.50},
             allocator=mock_allocator,
@@ -1130,6 +1153,48 @@ class TestPositionManagerWithAllocator:
         assert "D" not in sell_tickers, "단기 포지션 D는 매도 대상에서 제외되어야 합니다."
         assert "C" not in buy_tickers, "단기 포지션 C는 매수 대상에도 포함되지 않아야 합니다."
         assert "D" not in buy_tickers, "단기 포지션 D는 매수 대상에도 포함되지 않아야 합니다."
+
+    def test_jae100_untagged_position_protected_from_etf_topup(self):
+        """JAE-100 회귀: ETF 단독 리밸런싱 시 미태깅 장기 포지션은 매도되지 않는다.
+
+        시나리오: 6/2 ETF 자동 보충 매수가 trigger되었을 때, allocation.json에
+        ETF 종목만 태깅되어 있고 장기 보유 종목(KCC 등)이 untagged 상태로 남아 있다면,
+        기존 버그에서는 ETF target_weights에 없는 모든 보유 종목이 매도 대상이 되었다.
+        새 fix는 target pool(etf_rotation)에 태깅된 종목 + 새 시그널 종목만 허용한다.
+        """
+        # 보유: 002380(KCC, 미태깅 장기), 360750(ETF), 469150(ETF)
+        current = {"002380": 100, "360750": 50, "469150": 30}
+        prices = {"002380": 10_000, "360750": 20_000, "469150": 15_000}
+        portfolio_value = 3_000_000
+
+        pm = self._make_position_manager(current, portfolio_value, prices)
+
+        mock_allocator = MagicMock()
+
+        def _get_by_pool(pool):
+            if pool == "etf_rotation":
+                return [
+                    {"ticker": "360750", "pool": "etf_rotation"},
+                    {"ticker": "469150", "pool": "etf_rotation"},
+                ]
+            # 002380은 어떤 풀에도 태깅되지 않음 (미태깅 상태)
+            return []
+
+        mock_allocator.get_positions_by_pool.side_effect = _get_by_pool
+
+        # ETF 단독 리밸런싱: target = ETF 종목만, pool="etf_rotation"
+        sell_orders, _ = pm.calculate_rebalance_orders(
+            {"360750": 0.5, "469150": 0.5},
+            allocator=mock_allocator,
+            pool="etf_rotation",
+            integrated=False,
+        )
+
+        sell_tickers = {o["ticker"] for o in sell_orders}
+        # JAE-100 핵심 검증: 미태깅 장기 종목 002380이 매도 대상에 포함되면 안 됨
+        assert "002380" not in sell_tickers, (
+            "JAE-100 회귀: 미태깅 포지션은 ETF 단독 리밸런싱에서 보호되어야 합니다."
+        )
 
     def test_allocator_none_default_parameter(self):
         """allocator 파라미터의 기본값이 None이다."""

--- a/tests/test_merge_pool_targets.py
+++ b/tests/test_merge_pool_targets.py
@@ -460,3 +460,85 @@ class TestBackfillUntaggedPositions:
         count = alloc.backfill_untagged_positions(etf_tickers={"069500"})
 
         assert count == 0
+
+
+# ===================================================================
+# 5. JAE-100 회귀: auto_tag stale 정리는 미보유 종목에만 적용
+# ===================================================================
+
+
+class TestAutoTagStaleCleanupJae100:
+    """JAE-100 회귀: 새 시그널에 없는 종목이라도 실제 보유 중이면 태그를 유지한다.
+
+    기존 버그: auto_tag_from_pool_signals가 새 시그널에 없는 모든 태그를 stale로
+    간주해 삭제 → 백필된 장기 포지션이 매 리밸런싱마다 untag되어, 다음 ETF 단독
+    리밸런싱 시 다른 풀 제외 로직을 통과해 전량 매도 사고로 이어졌다.
+    """
+
+    def test_held_position_not_in_signal_keeps_tag(self, tmp_path):
+        """새 시그널에 없지만 KIS 잔고에 남아 있는 장기 종목은 태그가 유지된다."""
+        # KCC(002380) 보유 중. 6/1 리밸런싱 시그널에는 005930만 들어옴.
+        holdings = [
+            {"ticker": "002380", "eval_amount": 500_000, "current_price": 50000,
+             "qty": 10, "pnl": 0, "pnl_pct": 0.0},
+        ]
+        alloc = _make_allocator(tmp_path, holdings=holdings)
+
+        # 사전 조건: 002380 long_term 태깅 (백필된 상태)
+        alloc.tag_position("002380", "long_term", metadata={"backfilled": True})
+        assert alloc.get_position_pool("002380") == "long_term"
+
+        # 새 시그널에는 002380 없음
+        alloc.auto_tag_from_pool_signals({"long_term": {"005930": 1.0}})
+
+        # JAE-100 회귀: 002380이 보유 중이므로 태그가 유지되어야 함
+        assert alloc.get_position_pool("002380") == "long_term"
+        assert alloc.get_position_pool("005930") == "long_term"
+
+    def test_sold_position_tag_removed(self, tmp_path):
+        """KIS 잔고에 없고 시그널에도 없는 종목은 태그가 제거된다."""
+        # 잔고 비어 있음(완전 매도된 상태)
+        alloc = _make_allocator(tmp_path, holdings=[])
+
+        alloc.tag_position("005930", "long_term")
+        assert alloc.get_position_pool("005930") == "long_term"
+
+        # 005930 시그널에 없음 + 보유 X → 태그 제거 정상
+        alloc.auto_tag_from_pool_signals({"long_term": {"000660": 1.0}})
+
+        assert alloc.get_position_pool("005930") is None
+        assert alloc.get_position_pool("000660") == "long_term"
+
+    def test_balance_query_failure_skips_cleanup(self, tmp_path):
+        """KIS 잔고 조회 실패 시 stale 정리를 스킵하고 기존 태그를 보존한다."""
+        kis = _mock_kis()
+        alloc = PortfolioAllocator(
+            kis,
+            long_term_pct=0.70,
+            etf_rotation_pct=0.30,
+            allocation_path=_alloc_path(tmp_path),
+        )
+
+        alloc.tag_position("002380", "long_term")
+
+        # 잔고 조회 실패 모드로 전환
+        kis.get_balance.side_effect = Exception("KIS 점검 중")
+
+        alloc.auto_tag_from_pool_signals({"long_term": {"005930": 1.0}})
+
+        # 잔고 조회 실패 → stale 정리 스킵 → 002380 태그 유지
+        assert alloc.get_position_pool("002380") == "long_term"
+        assert alloc.get_position_pool("005930") == "long_term"
+
+    def test_new_signal_ticker_not_yet_in_balance(self, tmp_path):
+        """방금 시그널에 포함되어 태깅한 종목은 잔고 미반영이어도 보존된다."""
+        # 잔고에는 아직 없음(주문 직후 비동기 반영 전 상황)
+        alloc = _make_allocator(tmp_path, holdings=[])
+
+        alloc.auto_tag_from_pool_signals(
+            {"long_term": {"005930": 0.5, "000660": 0.5}}
+        )
+
+        # 방금 태깅된 종목은 잔고 미반영이어도 보존
+        assert alloc.get_position_pool("005930") == "long_term"
+        assert alloc.get_position_pool("000660") == "long_term"


### PR DESCRIPTION
## 배경
[JAE-99](/JAE/issues/JAE-99) — 2026-06-02 비-리밸런싱일에 KCC, 미래에셋증권, 한국전력, 한미반도체, 한화생명, KODEX 200, ACE AI반도체 등 장기 보유 종목이 전량 매도됨.

## 근본 원인 (3중 결함)

| # | 위치 | 결함 |
|---|------|------|
| 1 | `scheduler/main.py:execute_etf_topup` | `backfill_untagged_positions()` 미호출 → 미태깅 포지션이 풀-스코프 리밸런싱 시 보호받지 못함 |
| 2 | `position_manager.py:calculate_rebalance_orders` | 풀 제외 로직이 "다른 풀에 태깅된 종목" 만 제외 → 미태깅 포지션이 통과 |
| 3 | `portfolio_allocator.py:auto_tag_from_pool_signals` | 새 시그널에 없는 모든 비-short_term 태그를 stale 삭제 → 백필된 long_term 태그가 매 리밸런싱마다 휘발 |

6/1 실제 systemd 로그상 `자동 태그 정리: 5개 종목 태그 제거`가 확인되어 결함 #3 재현됨.

## 변경 내용
- 결함 #1: ETF 자동 보충 진입 시 `backfill_untagged_positions()` 선행 호출
- 결함 #2: 풀-스코프 리밸런싱은 target pool에 명시 태깅된 종목 + 새 target_weights 종목만 허용 (defense-in-depth)
- 결함 #3: stale 정리는 KIS 잔고에 없는(=실제 매도된) 종목에만 적용. 잔고 조회 실패 시 정리 스킵
- 회귀 테스트 5종 추가 (`TestAutoTagStaleCleanupJae100` 4건, `test_jae100_untagged_position_protected_from_etf_topup` 1건)
- 운영 복구 스크립트 `scripts/jae100_restore_allocation.py` 추가 (dry-run 기본)

## 테스트
- `tests/test_portfolio_allocator.py` 41건 통과
- `tests/test_merge_pool_targets.py` 35건 통과 (회귀 4건 신규)
- `tests/test_execution.py` 58건 통과 (회귀 1건 신규, 기존 풀 제외 테스트 3건은 새 의미론에 맞게 mock 정비)
- `tests/test_integrated_rebalance.py` 통과
- `tests/test_scheduler.py` 1건 사전 실패 (`test_get_etf_universe_uses_enhanced` — JAE-95 ETF 유니버스 확장 영향, JAE-100 무관)

## 운영 후속 (CEO 승인 필요)
1. **allocation.json 복구**: 운영 경로에서 `python scripts/jae100_restore_allocation.py --dry-run` 으로 사전 검증 후 `--apply` 실행
2. **systemd 재시작**: 봇이 메모리에 allocation 캐시를 들고 있으므로 파일 적용 후 재시작 필요. 재시작은 CEO 승인 게이트.
3. **2차 사고 방지 모니터링**: 다음 ETF topup 트리거 시 로그에 "미태깅 포지션 N개를 long_term으로 보강" 메시지 확인.

## Test plan
- [ ] PR 머지 후 운영 경로에서 `git pull`
- [ ] `scripts/jae100_restore_allocation.py --dry-run` 결과 CEO 검토
- [ ] `--apply` 적용 및 백업 확인
- [ ] CEO 승인 후 `sudo systemctl restart quant-bot`
- [ ] 다음 영업일(2026-06-03) 08:30 daily_cash_injection_check 로그 검토

이슈: [JAE-100](/JAE/issues/JAE-100), [JAE-99](/JAE/issues/JAE-99)

🤖 Generated with [Claude Code](https://claude.com/claude-code)