### PR TITLE
fix(execution): JAE-101 auto_tag stale 정리 정책 KIS 잔고 기반으로 정정

### DIFF
--- a/src/execution/portfolio_allocator.py
+++ b/src/execution/portfolio_allocator.py
@@ -473,20 +473,36 @@ class PortfolioAllocator:
             )
             tagged_count += 1
 
-        # 시그널에 없는 기존 태그 정리
-        with self._lock:
-            positions = self._data.get("positions", {})
-            stale = [
-                t for t in positions
-                if t not in ticker_best_pool
-                and positions[t].get("pool") != "short_term"
-            ]
-            for t in stale:
-                del positions[t]
-            if stale:
-                self._data["positions"] = positions
-                self._save()
-                logger.info("자동 태그 정리: %d개 종목 태그 제거", len(stale))
+        # 시그널에 없는 기존 태그 정리 — KIS 잔고 기반 (JAE-101)
+        # 정책: 보유 종목 태그는 보존한다. "시그널 미포함"은 stale 판정 근거가 아니다.
+        # 실제 매도되어 KIS 잔고에 없는 종목만 제거한다.
+        # 잔고 조회 실패 시 정리 자체를 스킵 (보수적 처리).
+        try:
+            balance = self._kis_client.get_balance()
+            held_tickers: Optional[set[str]] = {
+                h.get("ticker")
+                for h in balance.get("holdings", [])
+                if h.get("ticker") and h.get("qty", 0) > 0
+            }
+        except Exception as e:
+            logger.warning("자동 태깅 stale 정리 중 잔고 조회 실패 — 정리 스킵: %s", e)
+            held_tickers = None
+
+        if held_tickers is not None:
+            with self._lock:
+                positions = self._data.get("positions", {})
+                stale = [
+                    t for t in positions
+                    if t not in held_tickers
+                    and t not in ticker_best_pool
+                    and positions[t].get("pool") != "short_term"
+                ]
+                for t in stale:
+                    del positions[t]
+                if stale:
+                    self._data["positions"] = positions
+                    self._save()
+                    logger.info("자동 태그 정리: %d개 종목 태그 제거", len(stale))
 
         logger.info("자동 태깅 완료: %d개 종목", tagged_count)
 

--- a/tests/test_merge_pool_targets.py
+++ b/tests/test_merge_pool_targets.py
@@ -460,3 +460,110 @@ class TestBackfillUntaggedPositions:
         count = alloc.backfill_untagged_positions(etf_tickers={"069500"})
 
         assert count == 0
+
+
+# ===================================================================
+# 5. JAE-101: auto_tag stale 정리 — KIS 잔고 기반
+# ===================================================================
+
+
+class TestAutoTagStaleCleanupJae101:
+    """JAE-101: stale 정리는 KIS 잔고에 없는 종목에만 적용한다.
+
+    배경: 기존 정책은 새 시그널에 없는 모든 long_term/etf_rotation 태그를
+    매 리밸런싱마다 삭제했다. 전략 num_stocks 제약으로 시그널 종목이 보유
+    종목보다 적은 경우, 실제 보유 중인 종목 태그가 wipe되어 allocation.json이
+    부분 정보 상태가 되었다. 새 정책은 'KIS 잔고에 없는 종목'만 stale로 판정한다.
+    """
+
+    def test_held_position_not_in_signal_keeps_tag(self, tmp_path):
+        """KIS 잔고에 보유 중이지만 새 시그널에 없는 종목은 태그를 유지한다."""
+        holdings = [
+            {"ticker": "002380", "eval_amount": 500_000, "current_price": 250000,
+             "qty": 2, "pnl": 0, "pnl_pct": 0.0},
+            {"ticker": "005930", "eval_amount": 300_000, "current_price": 75000,
+             "qty": 4, "pnl": 0, "pnl_pct": 0.0},
+        ]
+        alloc = _make_allocator(tmp_path, holdings=holdings)
+
+        alloc.tag_position("002380", "long_term")
+        alloc.tag_position("005930", "long_term")
+
+        pool_signals = {
+            "long_term": {"005930": 1.0},
+            "etf_rotation": {},
+        }
+        alloc.auto_tag_from_pool_signals(pool_signals)
+
+        assert alloc.get_position_pool("002380") == "long_term"
+        assert alloc.get_position_pool("005930") == "long_term"
+
+    def test_sold_position_tag_removed(self, tmp_path):
+        """실제 매도되어 KIS 잔고에 없는 종목은 태그를 제거한다."""
+        holdings = [
+            {"ticker": "005930", "eval_amount": 500_000, "current_price": 75000,
+             "qty": 6, "pnl": 0, "pnl_pct": 0.0},
+        ]
+        alloc = _make_allocator(tmp_path, holdings=holdings)
+
+        alloc.tag_position("002380", "long_term")
+        alloc.tag_position("005930", "long_term")
+
+        pool_signals = {
+            "long_term": {"005930": 1.0},
+            "etf_rotation": {},
+        }
+        alloc.auto_tag_from_pool_signals(pool_signals)
+
+        assert alloc.get_position_pool("002380") is None
+        assert alloc.get_position_pool("005930") == "long_term"
+
+    def test_balance_query_failure_skips_cleanup(self, tmp_path):
+        """KIS 점검 시간대 등 잔고 조회 실패 시 stale 정리를 스킵한다.
+
+        보수적 처리: 잔고를 알 수 없는 상태에서 임의로 태그를 제거하면
+        데이터 정합성이 깨질 수 있으므로, 정리 자체를 스킵하고 태깅만 수행한다.
+        """
+        kis = _mock_kis()
+        alloc = PortfolioAllocator(
+            kis,
+            long_term_pct=0.70,
+            etf_rotation_pct=0.30,
+            allocation_path=_alloc_path(tmp_path),
+        )
+
+        alloc.tag_position("002380", "long_term")
+        alloc.tag_position("005930", "long_term")
+
+        kis.get_balance.side_effect = Exception("KIS 점검 중")
+
+        pool_signals = {
+            "long_term": {"069500": 1.0},
+            "etf_rotation": {},
+        }
+        alloc.auto_tag_from_pool_signals(pool_signals)
+
+        assert alloc.get_position_pool("002380") == "long_term"
+        assert alloc.get_position_pool("005930") == "long_term"
+        assert alloc.get_position_pool("069500") == "long_term"
+
+    def test_new_signal_ticker_not_yet_in_balance(self, tmp_path):
+        """방금 시그널에 포함되어 태깅된 종목은 KIS 잔고 반영 전이라도 보존한다.
+
+        리밸런싱 주문 직후 KIS 잔고 동기화 전 race condition 방어:
+        새 시그널에 포함된 종목(ticker_best_pool)은 잔고에 없더라도 stale로 보지 않는다.
+        """
+        holdings = [
+            {"ticker": "005930", "eval_amount": 500_000, "current_price": 75000,
+             "qty": 6, "pnl": 0, "pnl_pct": 0.0},
+        ]
+        alloc = _make_allocator(tmp_path, holdings=holdings)
+
+        pool_signals = {
+            "long_term": {"005930": 1.0},
+            "etf_rotation": {"069500": 1.0},
+        }
+        alloc.auto_tag_from_pool_signals(pool_signals)
+
+        assert alloc.get_position_pool("005930") == "long_term"
+        assert alloc.get_position_pool("069500") == "etf_rotation"


### PR DESCRIPTION
## 요약

`auto_tag_from_pool_signals`의 stale 일괄 삭제 정책을 **KIS 잔고 기반 정리**로 정정한다. 시그널 미포함은 stale 판정 근거가 아니다.

이슈: [JAE-101](/JAE/issues/JAE-101)

## 배경

- 기존 정책은 새 시그널에 없는 모든 long_term/etf_rotation 태그를 매 리밸런싱마다 삭제했음
- 전략 `num_stocks=7 + ETF 2 = 9` 제약으로 보유 종목보다 시그널이 적으면 실제 보유 종목 태그가 wipe됨
- `portfolio_allocation.json`이 매 리밸런싱 직후 부분 정보 상태로 잔존 → `get_long_term_cash()` 과대평가, 드리프트 왜곡 등 데이터 정합성 문제 유발
- 6/1 systemd 로그에서 실제 재현: backfill 6개 직후 stale wipe 5개

## 변경 사항

`src/execution/portfolio_allocator.py:476-489`의 stale 정리 블록을 다음과 같이 변경:

1. `kis_client.get_balance()`로 실제 보유 잔고 조회
2. `held_tickers`(qty>0 종목) ∪ `ticker_best_pool`(새 시그널 종목) ∪ `short_term` 풀은 보호 대상
3. 잔고 조회 실패 시 stale 정리 자체를 스킵 (보수적 처리)

## 회귀 테스트 (4건 추가)

`tests/test_merge_pool_targets.py::TestAutoTagStaleCleanupJae101`:

1. `test_held_position_not_in_signal_keeps_tag` — 잔고 보유 + 시그널 미포함 → 태그 유지
2. `test_sold_position_tag_removed` — 잔고 없음 + 시그널 미포함 → 태그 제거
3. `test_balance_query_failure_skips_cleanup` — KIS 점검 → 정리 스킵
4. `test_new_signal_ticker_not_yet_in_balance` — 시그널 포함 + 잔고 미반영 → 보존

## 검증

```
$ python -m pytest tests/test_merge_pool_targets.py
29 passed in 6.30s

$ python -m pytest tests/ -k "allocator or merge_pool or executor or rebalance or risk_guard"
141 passed in 112.09s
```

## 영향 범위

- 실거래 자산 배분 로직(`portfolio_allocator`)이 수정되지만 **전략 시그널/유니버스/리밸런싱 주기는 변경되지 않음**
- 매 리밸런싱마다 `allocation.json`이 KIS 실잔고를 정확히 반영하게 되어 데이터 정합성 회복
- 운영 트리거였던 [JAE-65 ETF 자동 보충](https://github.com/Y-JaeHyun/WUBU/pull/17)은 이미 revert되어 진입점은 차단된 상태

🤖 Generated with [Claude Code](https://claude.com/claude-code)